### PR TITLE
Support self-signed certificates for sds-replicated-volume

### DIFF
--- a/common-hooks/tls-certificate/internal_tls.go
+++ b/common-hooks/tls-certificate/internal_tls.go
@@ -363,7 +363,7 @@ func GenerateSelfSignedTLSIfNeeded(
 
 		// if common ca and cert ca are not equal - regenerate cert
 		if useCommonCA && !slices.Equal(auth.Cert, currentCert.CA) {
-			input.Logger.Warn("common ca is not equal cert ca")
+			input.Logger.Info("common ca is not equal cert ca")
 
 			caOutdated = true
 		}

--- a/common-hooks/tls-certificate/internal_tls.go
+++ b/common-hooks/tls-certificate/internal_tls.go
@@ -147,17 +147,17 @@ type GenSelfSignedTLSHookConf struct {
 	CertExpiryDuration time.Duration
 }
 
-func (gss GenSelfSignedTLSHookConf) Path() string {
-	return strings.TrimSuffix(gss.FullValuesPathPrefix, ".")
+func (conf GenSelfSignedTLSHookConf) Path() string {
+	return strings.TrimSuffix(conf.FullValuesPathPrefix, ".")
 }
 
-func (gss GenSelfSignedTLSHookConf) CommonCAPath() string {
-	return strings.TrimSuffix(gss.CommonCAValuesPath, ".")
+func (conf GenSelfSignedTLSHookConf) CommonCAPath() string {
+	return strings.TrimSuffix(conf.CommonCAValuesPath, ".")
 }
 
-func (gss GenSelfSignedTLSHookConf) UsagesStrings() []string {
-	usageStrs := make([]string, 0, len(gss.Usages))
-	for _, usage := range gss.Usages {
+func (conf GenSelfSignedTLSHookConf) UsagesStrings() []string {
+	usageStrs := make([]string, 0, len(conf.Usages))
+	for _, usage := range conf.Usages {
 		usageStrs = append(usageStrs, string(usage))
 	}
 	return usageStrs
@@ -379,7 +379,8 @@ func GenerateSelfSignedTLSIfNeeded(
 	}
 
 	if mustGenerate {
-		if newCert, err := GenerateNewSelfSignedTLS(
+		var newCert *certificate.Certificate
+		if newCert, err = GenerateNewSelfSignedTLS(
 			SelfSignedCertValues{
 				CA:           auth,
 				CN:           conf.CN,
@@ -393,9 +394,8 @@ func GenerateSelfSignedTLSIfNeeded(
 			},
 		); err != nil {
 			return false, fmt.Errorf("generate new self signed tls: %w", err)
-		} else {
-			*currentCert = *newCert
 		}
+		*currentCert = *newCert
 	}
 
 	input.Values.Set(conf.Path(), convCertToValues(currentCert))


### PR DESCRIPTION
The goal of this change is to reduce code duplication between [this sds-replicated-volume PR](https://github.com/deckhouse/sds-replicated-volume/pull/223) and module-sdk, and to propose valuable improvements in a backward-compatible way.

In short, the use case of sds-replicated-volume is the following:
 - We have manual certificate renewal hook, which will turn off LINSTOR, renew certificates and turn it back on. We want the renewal to be as close to the module-sdk implementation as possible
 - We also have normal cert renewal hooks from module-sdk
 - We have some specific certificate requirements, which conflict with current module-sdk defaults (like expiration durations)

**Improvements**
 - support specifying new optional configs in `GenSelfSignedTLSHookConf`: `CertOutdatedDuration`, `CAExpiryDuration`, `CertExpiryDuration`, and expose current defaults for them as `DefaultCertOutdatedDuration`, `DefaultCAExpiryDuration`, `DefaultCertExpiryDuration`
- improve `isIrrelevantCert` with IPv6 addresses support
- improve `isIrrelevantCert` with `KeyUsages` and `ExtKeyUsages` checks, so that such changes would trigger cert regeneration
- when `CommonCAValuesPath` is not set, but `CommonCACanonicalName` is set, use it as CA CN, when generating new CA. Currently we are using cert's CN, even if `CommonCACanonicalName` was set, which is not convenient, since there's no way to change CA CN, if `CommonCAValuesPath` is not set
- remove ineffective "requestheader-client" key usage
- improve documentation and comments in a few places
- improve logging and errors in a few places

**Refactor**
 - extract and publish `GenerateSelfSignedTLSIfNeeded` function from `GenSelfSignedTLS`. This is needed to support the use-case of manual cert renewal
- put all validation and defaults into `validateAndApplyDefaults` function, which simplified the code
- use more modern way of comparing arrays - refactor `arraysAreEqual` with unexpected in-place sorting into `slices.EqualFunc` with explicit sorting.
- introduce `UsagesStrings` helper, since it helped to reduce big function


