### PR TITLE
[chore] add support for deployment in storage hook

### DIFF
--- a/common-hooks/storage-class-change/hook.go
+++ b/common-hooks/storage-class-change/hook.go
@@ -250,6 +250,14 @@ func storageClassChange(ctx context.Context, input *pkg.HookInput, args Args) er
 				},
 			}
 			err = kubeClient.Delete(ctx, obj)
+		case "Deployment":
+			obj := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      args.ObjectName,
+					Namespace: args.Namespace,
+				},
+			}
+			err = kubeClient.Delete(ctx, obj)
 		default:
 			return fmt.Errorf("unknown object kind %s", args.ObjectKind)
 		}


### PR DESCRIPTION
The hook now supports deployment. When storage class changed the hook deletes deployment.