### PR TITLE
[module-sdk] config is not gen if a hook has only ReadinessProbe

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -168,7 +168,7 @@ func (c *HookController) CheckSettings(ctx context.Context) error {
 var ErrNoHooksRegistered = errors.New("no hooks registered")
 
 func (c *HookController) PrintHookConfigs() error {
-	if len(c.registry.Executors()) == 0 && c.settingsCheck == nil {
+	if len(c.registry.Executors()) == 0 && c.settingsCheck == nil && c.registry.Readiness() == nil {
 		return ErrNoHooksRegistered
 	}
 
@@ -205,7 +205,7 @@ func (c *HookController) PrintHookConfigs() error {
 }
 
 func (c *HookController) WriteHookConfigsInFile() error {
-	if len(c.registry.Executors()) == 0 {
+	if len(c.registry.Executors()) == 0 && c.settingsCheck == nil && c.registry.Readiness() == nil {
 		return ErrNoHooksRegistered
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -205,7 +205,7 @@ func (c *HookController) PrintHookConfigs() error {
 }
 
 func (c *HookController) WriteHookConfigsInFile() error {
-	if len(c.registry.Executors()) == 0 && c.settingsCheck == nil && c.registry.Readiness() == nil {
+	if len(c.registry.Executors()) == 0 && c.registry.Readiness() == nil {
 		return ErrNoHooksRegistered
 	}
 


### PR DESCRIPTION
The `PrintHookConfigs` method returned error if `len(executors) == 0 && settingsCheck == nil`, without checking for readiness probe. 
Readiness was added to the config only after this check, so the execution did not reach it. 
There was a similar problem in `WriteHookConfigsInFile`