### PR TITLE
[fix] return exit code 0 when settings check passes 

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -154,12 +154,17 @@ func (c *HookController) RunReadiness(ctx context.Context) error {
 func (c *HookController) CheckSettings(ctx context.Context) error {
 	res := settingscheck.Execute(ctx, c.settingsCheck, c.dc, c.logger)
 
+	if res.Valid && len(res.Warnings) == 0 && res.Message == "" {
+		os.Exit(0)
+		return nil
+	}
+
 	buf := bytes.NewBuffer([]byte{})
 	if err := json.NewEncoder(buf).Encode(res); err != nil {
 		return fmt.Errorf("encode error: %w", err)
 	}
 
-	fmt.Fprintln(os.Stderr, buf.String())
+	fmt.Fprint(os.Stderr, buf.String())
 	os.Exit(1)
 
 	return nil


### PR DESCRIPTION
Previously CheckSettings always exited with code 1 and wrote JSON to stderr regardless of the validation outcome. Now it exits with 0 when the result is valid with no warnings and no message, and only writes the JSON structure to stderr on exit 1.

Before (always exit 1, always stderr):

replicas: 0 → exit: 1, stderr: {"valid":false,"message":"replicas cannot be 0","warnings":null}
replicas: 1 → exit: 1, stderr: {"valid":true,"message":"","warnings":null}
replicas: 2 → exit: 1, stderr: {"valid":true,"message":"","warnings":["replicas cannot be greater than 3"]}

After (exit 0 when fully valid, stderr only when needed):

replicas: 0 → exit: 1, stderr: {"valid":false,"message":"replicas cannot be 0","warnings":null}
replicas: 1 → exit: 0, stderr: empty
replicas: 2 → exit: 1, stderr: {"valid":true,"message":"","warnings":["replicas cannot be greater than 3"]}

