### PR TITLE
[feature] add OnBeforeDeleteHelm binding to module hook config

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -295,6 +295,9 @@ func remapModuleHookConfig(cfg *pkg.HookConfig, out *gohook.HookConfig) {
 	if cfg.OnAfterHelm != nil {
 		out.OnAfterHelm = ptr.To(cfg.OnAfterHelm.Order)
 	}
+	if cfg.OnBeforeDeleteHelm != nil {
+		out.OnBeforeDeleteHelm = ptr.To(cfg.OnBeforeDeleteHelm.Order)
+	}
 	if cfg.OnAfterDeleteHelm != nil {
 		out.OnAfterDeleteHelm = ptr.To(cfg.OnAfterDeleteHelm.Order)
 	}
@@ -322,6 +325,9 @@ func remapApplicationHookConfig(cfg *pkg.ApplicationHookConfig, out *gohook.Hook
 	}
 	if cfg.OnAfterHelm != nil {
 		out.OnAfterHelm = ptr.To(cfg.OnAfterHelm.Order)
+	}
+	if cfg.OnBeforeDeleteHelm != nil {
+		out.OnBeforeDeleteHelm = ptr.To(cfg.OnBeforeDeleteHelm.Order)
 	}
 	if cfg.OnAfterDeleteHelm != nil {
 		out.OnAfterDeleteHelm = ptr.To(cfg.OnAfterDeleteHelm.Order)

--- a/pkg/hook.go
+++ b/pkg/hook.go
@@ -138,10 +138,11 @@ type HookConfig struct {
 	// OnStartup runs hook on module/global startup
 	// Attention! During the startup you don't have snapshots available
 	// use native KubeClient to fetch resources
-	OnStartup         *OrderedConfig
-	OnBeforeHelm      *OrderedConfig
-	OnAfterHelm       *OrderedConfig
-	OnAfterDeleteHelm *OrderedConfig
+	OnStartup          *OrderedConfig
+	OnBeforeHelm       *OrderedConfig
+	OnAfterHelm        *OrderedConfig
+	OnBeforeDeleteHelm *OrderedConfig
+	OnAfterDeleteHelm  *OrderedConfig
 
 	AllowFailure bool
 	Queue        string
@@ -195,10 +196,11 @@ type ApplicationHookConfig struct {
 	// OnStartup runs hook on application startup
 	// Attention! During the startup you don't have snapshots available
 	// use native KubeClient to fetch resources
-	OnStartup         *OrderedConfig
-	OnBeforeHelm      *OrderedConfig
-	OnAfterHelm       *OrderedConfig
-	OnAfterDeleteHelm *OrderedConfig
+	OnStartup          *OrderedConfig
+	OnBeforeHelm       *OrderedConfig
+	OnAfterHelm        *OrderedConfig
+	OnBeforeDeleteHelm *OrderedConfig
+	OnAfterDeleteHelm  *OrderedConfig
 
 	AllowFailure bool
 	Queue        string

--- a/pkg/hook/dto.go
+++ b/pkg/hook/dto.go
@@ -32,11 +32,12 @@ type HookConfig struct {
 	// OnStartup runs hook on module/global startup
 	// Attention! During the startup you don't have snapshots available
 	// use native KubeClient to fetch resources
-	OnStartup         *uint `yaml:"onStartup,omitempty" json:"onStartup,omitempty"`
-	OnBeforeHelm      *uint `yaml:"beforeHelm,omitempty" json:"beforeHelm,omitempty"`
-	OnAfterHelm       *uint `yaml:"afterHelm,omitempty" json:"afterHelm,omitempty"`
-	OnAfterDeleteHelm *uint `yaml:"afterDeleteHelm,omitempty" json:"afterDeleteHelm,omitempty"`
-	AllowFailure      *bool `yaml:"allowFailure,omitempty" json:"allowFailure,omitempty"`
+	OnStartup          *uint `yaml:"onStartup,omitempty" json:"onStartup,omitempty"`
+	OnBeforeHelm       *uint `yaml:"beforeHelm,omitempty" json:"beforeHelm,omitempty"`
+	OnAfterHelm        *uint `yaml:"afterHelm,omitempty" json:"afterHelm,omitempty"`
+	OnBeforeDeleteHelm *uint `yaml:"beforeDeleteHelm,omitempty" json:"beforeDeleteHelm,omitempty"`
+	OnAfterDeleteHelm  *uint `yaml:"afterDeleteHelm,omitempty" json:"afterDeleteHelm,omitempty"`
+	AllowFailure       *bool `yaml:"allowFailure,omitempty" json:"allowFailure,omitempty"`
 
 	Settings *HookConfigSettings `yaml:"settings,omitempty" json:"settings,omitempty"`
 


### PR DESCRIPTION
Adds `OnBeforeDeleteHelm` to module hook configuration so a hook authored with module-sdk can register for the new `beforeDeleteHelm` lifecycle binding (fires just before `helm uninstall` of a module's release). Mirrors the existing `OnAfterDeleteHelm` everywhere it appears.

- `pkg/hook.go` — new `*OrderedConfig` field in `HookConfig` and `ApplicationHookConfig`
- `pkg/hook/dto.go` — DTO field with `yaml/json:"beforeDeleteHelm,omitempty"`
- `internal/controller/controller.go` — conversion in `remapModuleHookConfig` and `remapApplicationHookConfig`