### PR TITLE
[module-sdk] feat: improve tls generator

### DIFF
--- a/common-hooks/tls-certificate/internal_tls.go
+++ b/common-hooks/tls-certificate/internal_tls.go
@@ -19,7 +19,6 @@ package tlscertificate
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -101,11 +100,18 @@ type GenSelfSignedTLSHookConf struct {
 	//   CommonCAValuesPath
 	// Example: CommonCAValuesPath =  'commonCaPath'
 	// Values to store:
-	// commonCaPath.key
-	// commonCaPath.crt
+	// commonCaPath.<CommonCACertField>  (default: commonCaPath.crt)
+	// commonCaPath.<CommonCAKeyField>   (default: commonCaPath.key)
 	// Data in values store as plain text
 	// In helm templates you need use `b64enc` function to encode
 	CommonCAValuesPath string
+	// CommonCACertField - field name for the cert within CommonCAValuesPath object.
+	// Defaults to "crt" if empty.
+	// Example: set to "cert" if the CA is stored as commonCaPath.cert instead of commonCaPath.crt
+	CommonCACertField string
+	// CommonCAKeyField - field name for the key within CommonCAValuesPath object.
+	// Defaults to "key" if empty.
+	CommonCAKeyField string
 	// Canonical name (CN) of common CA certificate.
 	// If not specified (empty), then (if no CA cert already generated) using CN property of this struct
 	CommonCACanonicalName string
@@ -132,6 +138,20 @@ func (gss GenSelfSignedTLSHookConf) Path() string {
 
 func (gss GenSelfSignedTLSHookConf) CommonCAPath() string {
 	return strings.TrimSuffix(gss.CommonCAValuesPath, ".")
+}
+
+func (gss GenSelfSignedTLSHookConf) CACertField() string {
+	if gss.CommonCACertField == "" {
+		return "crt"
+	}
+	return gss.CommonCACertField
+}
+
+func (gss GenSelfSignedTLSHookConf) CAKeyField() string {
+	if gss.CommonCAKeyField == "" {
+		return "key"
+	}
+	return gss.CommonCAKeyField
 }
 
 // SANsGenerator function for generating sans
@@ -281,7 +301,7 @@ func GenSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 		// 2.2) save new common ca in values
 		// 2.3) mark certificates to regenerate
 		if useCommonCA {
-			auth, err = getCommonCA(input, conf.CommonCAPath(), caExpiryDuration, caOutdatedDuration)
+			auth, err = getCommonCA(input, conf.CommonCAPath(), conf.CACertField(), conf.CAKeyField(), caExpiryDuration, caOutdatedDuration)
 			if err != nil {
 				commonCACanonicalName := conf.CommonCACanonicalName
 
@@ -298,7 +318,8 @@ func GenSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 					return fmt.Errorf("generate ca: %w", err)
 				}
 
-				input.Values.Set(conf.CommonCAPath(), auth)
+				input.Values.Set(conf.CommonCAPath()+"."+conf.CACertField(), string(auth.Cert))
+				input.Values.Set(conf.CommonCAPath()+"."+conf.CAKeyField(), string(auth.Key))
 
 				mustGenerate = true
 			}
@@ -384,17 +405,20 @@ func convCertToValues(cert *certificate.Certificate) CertValues {
 var ErrCertificateIsNotFound = errors.New("certificate is not found")
 var ErrCAIsInvalidOrOutdated = errors.New("ca is invalid or outdated")
 
-func getCommonCA(input *pkg.HookInput, valKey string, caExpiryDuration, caOutdatedDuration time.Duration) (*certificate.Authority, error) {
-	auth := new(certificate.Authority)
-
-	ca, ok := input.Values.GetOk(valKey)
+func getCommonCA(input *pkg.HookInput, valKey, certField, keyField string, caExpiryDuration, caOutdatedDuration time.Duration) (*certificate.Authority, error) {
+	certVal, ok := input.Values.GetOk(valKey + "." + certField)
 	if !ok {
 		return nil, ErrCertificateIsNotFound
 	}
 
-	err := json.Unmarshal([]byte(ca.String()), auth)
-	if err != nil {
-		return nil, err
+	keyVal, ok := input.Values.GetOk(valKey + "." + keyField)
+	if !ok {
+		return nil, ErrCertificateIsNotFound
+	}
+
+	auth := &certificate.Authority{
+		Cert: []byte(certVal.String()),
+		Key:  []byte(keyVal.String()),
 	}
 
 	outdated, err := isOutdatedCA(auth.Cert, caExpiryDuration, caOutdatedDuration)

--- a/common-hooks/tls-certificate/internal_tls_test.go
+++ b/common-hooks/tls-certificate/internal_tls_test.go
@@ -548,6 +548,64 @@ func Test_GenSelfSignedTLS(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("common ca with custom cert field name", func(t *testing.T) {
+		dc := mock.NewDependencyContainerMock(t)
+
+		snapshots := mock.NewSnapshotsMock(t)
+		snapshots.GetMock.When(tlscertificate.InternalTLSSnapshotKey).Then([]pkg.Snapshot{})
+
+		ca, err := certificate.GenerateCA(
+			"cert-name",
+			certificate.WithKeyAlgo("ecdsa"),
+			certificate.WithKeySize(256),
+			certificate.WithCAExpiry(tenYears))
+		assert.NoError(t, err)
+
+		values := mock.NewOutputPatchableValuesCollectorMock(t)
+
+		values.GetMock.When("global.discovery.clusterDomain").Then(gjson.Result{Type: gjson.String, Str: "cluster.local"})
+		values.GetMock.When("global.modules.publicDomainTemplate").Then(gjson.Result{Type: gjson.String, Str: "%s.127.0.0.1.sslip.io"})
+
+		// CA is stored at custom field name "cert" instead of default "crt"
+		values.GetOkMock.When("global.internal.modules.kubeRBACProxyCA.cert").Then(gjson.Result{Type: gjson.String, Str: string(ca.Cert)}, true)
+		values.GetOkMock.When("global.internal.modules.kubeRBACProxyCA.key").Then(gjson.Result{Type: gjson.String, Str: string(ca.Key)}, true)
+
+		values.SetMock.Set(func(path string, v any) {
+			assert.Equal(t, "d8-example-module.internal.kubeRBACProxyCert", path)
+
+			vals, ok := v.(tlscertificate.CertValues)
+			assert.True(t, ok)
+
+			assert.NotEmpty(t, vals.CA)
+			assert.NotEmpty(t, vals.Crt)
+			assert.NotEmpty(t, vals.Key)
+
+			parsedCert, err := certificate.ParseCertificate([]byte(vals.Crt))
+			assert.NoError(t, err)
+			assert.Equal(t, parsedCert.Issuer.CommonName, "cert-name")
+		})
+
+		var input = &pkg.HookInput{
+			Snapshots: snapshots,
+			Values:    values,
+			DC:        dc,
+			Logger:    log.NewNop(),
+		}
+
+		config := tlscertificate.GenSelfSignedTLSHookConf{
+			CN:                   "cert-name",
+			TLSSecretName:        "secret-kube-rbac-proxy-cert",
+			Namespace:            "some-namespace",
+			SANs:                 tlscertificate.DefaultSANs([]string{"example-svc"}),
+			FullValuesPathPrefix: "d8-example-module.internal.kubeRBACProxyCert",
+			CommonCAValuesPath:   "global.internal.modules.kubeRBACProxyCA",
+			CommonCACertField:    "cert",
+		}
+
+		err = tlscertificate.GenSelfSignedTLS(config)(context.Background(), input)
+		assert.NoError(t, err)
+	})
+
 	t.Run("wrong certificate expiry duration in snapshot", func(t *testing.T) {
 		dc := mock.NewDependencyContainerMock(t)
 


### PR DESCRIPTION
**Allow configuring CA field names in `GenSelfSignedTLSHookConf`**

Add two optional fields — `CommonCACertField` and `CommonCAKeyField` — to `GenSelfSignedTLSHookConf` that control the subkey names used to read and write the CA cert and key within `CommonCAValuesPath`.

Previously, the hook always assumed the CA was stored as `<path>.crt` / `<path>.key`. This made it impossible to source a CA that uses different field naming, such as Deckhouse's `global.internal.modules.kubeRBACProxyCA`, which stores the cert under `.cert` instead of `.crt`.

Both fields default to their original values (`"crt"` and `"key"`), so the change is fully backward-compatible.