### PR TITLE
[feat] add openapi defaults handling for tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -105,6 +105,17 @@ After `RunHook`, you assert on:
 - collected metrics,
 - captured logs.
 
+The framework can also seed values and config values with defaults from the module's OpenAPI schemas (`openapi/values.yaml`, `openapi/config-values.yaml`), so a test sees the same starting state addon-operator would build in production:
+
+```go
+f := framework.NewHookExecutionConfig(t, cfg, handler,
+    framework.WithOpenAPIDir("../openapi"),
+    framework.WithInitialValues(`{"https": {"mode": "CertManager"}}`),
+)
+```
+
+Schema defaults form the baseline; `WithInitialValues` is deep-merged on top so the test always wins on conflicts. See [`testing/framework/README.md`](./testing/framework/README.md#openapi-defaults) for details.
+
 Typical test:
 
 ```go

--- a/examples/example-module/hooks/subfolder/openapi_framework_test.go
+++ b/examples/example-module/hooks/subfolder/openapi_framework_test.go
@@ -1,0 +1,155 @@
+package hookinfolder_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/module-sdk/pkg"
+	"github.com/deckhouse/module-sdk/testing/framework"
+
+	subfolder "example-module/subfolder"
+)
+
+// openapiDir is the path to this module's OpenAPI schemas, resolved
+// relative to this test file. The schemas live next to `hooks/` in
+// `examples/example-module/openapi/`.
+const openapiDir = "../../openapi"
+
+// TestOpenAPI_DefaultsSeedValuesStore demonstrates the WithOpenAPIDir
+// option: the framework reads the module's OpenAPI schemas and pre-seeds
+// the values / config-values stores with every `default:` declared by
+// them, exactly like addon-operator does in production.
+//
+// This is the most realistic starting point for a hook test in a module
+// that ships an `openapi/` directory: hooks running under the framework
+// observe the same defaults a real cluster would see.
+func TestOpenAPI_DefaultsSeedValuesStore(t *testing.T) {
+	cfg := &pkg.HookConfig{
+		Metadata:     pkg.HookMetadata{Name: "openapi-defaults-demo"},
+		OnBeforeHelm: &pkg.OrderedConfig{Order: 1},
+	}
+
+	// A small hook that branches on the `https.mode` config value. In a
+	// real test you would point this at one of your handlers; here we
+	// keep it inline so the assertion is right next to the schema fields
+	// it exercises.
+	handler := func(_ context.Context, input *pkg.HookInput) error {
+		mode := input.Values.Get("https.mode").String()
+		input.Values.Set("module.runtime.https.enabled", mode != "Disabled")
+		input.Values.Set("module.runtime.replicas", input.ConfigValues.Get("replicas").Int())
+		return nil
+	}
+
+	hec := framework.NewHookExecutionConfig(t, cfg, handler,
+		framework.WithOpenAPIDir(openapiDir),
+	)
+	hec.RunHook()
+	require.NoError(t, hec.HookError())
+
+	// Defaults from openapi/config-values.yaml.
+	assert.EqualValues(t, 1, hec.ConfigValuesGet("replicas").Int(),
+		"replicas default should come from config-values.yaml")
+	assert.Equal(t, "Disabled", hec.ConfigValuesGet("https.mode").String())
+	assert.Equal(t, "letsencrypt",
+		hec.ConfigValuesGet("https.certManager.clusterIssuerName").String())
+
+	// Values inherit config-values via x-extend, plus get their own
+	// schema-only fields.
+	assert.Equal(t, "Disabled", hec.ValuesGet("https.mode").String(),
+		"values must inherit https.mode default via x-extend")
+	assert.True(t, hec.ValuesGet("internal.golangVersions").Exists(),
+		"values.yaml-only defaults (internal.*) must be present")
+
+	// And the hook's own writes land on top of the schema defaults.
+	assert.False(t, hec.ValuesGet("module.runtime.https.enabled").Bool())
+	assert.EqualValues(t, 1, hec.ValuesGet("module.runtime.replicas").Int())
+}
+
+// TestOpenAPI_UserOverridesWin pins the override semantics: anything
+// passed via WithInitialValues / WithInitialConfigValues is deep-merged
+// on top of the schema defaults, so the test author always wins.
+func TestOpenAPI_UserOverridesWin(t *testing.T) {
+	cfg := &pkg.HookConfig{
+		Metadata:     pkg.HookMetadata{Name: "openapi-user-overrides"},
+		OnBeforeHelm: &pkg.OrderedConfig{Order: 1},
+	}
+
+	handler := func(_ context.Context, input *pkg.HookInput) error {
+		input.Values.Set("module.runtime.https.enabled",
+			input.Values.Get("https.mode").String() != "Disabled")
+		return nil
+	}
+
+	hec := framework.NewHookExecutionConfig(t, cfg, handler,
+		framework.WithOpenAPIDir(openapiDir),
+		framework.WithInitialConfigValues(`
+replicas: 5
+https:
+  mode: CertManager
+  certManager:
+    clusterIssuerName: my-issuer
+`),
+		framework.WithInitialValues(`
+https:
+  mode: CertManager
+`),
+	)
+	hec.RunHook()
+	require.NoError(t, hec.HookError())
+
+	// Explicit overrides win.
+	assert.EqualValues(t, 5, hec.ConfigValuesGet("replicas").Int())
+	assert.Equal(t, "CertManager", hec.ConfigValuesGet("https.mode").String())
+	assert.Equal(t, "my-issuer",
+		hec.ConfigValuesGet("https.certManager.clusterIssuerName").String())
+
+	// Untouched defaults survive: customCertificate.secretName is set by
+	// the schema and was not overridden.
+	assert.Equal(t, "false",
+		hec.ConfigValuesGet("https.customCertificate.secretName").String())
+
+	// And the hook's branch on https.mode picked up the override.
+	assert.True(t, hec.ValuesGet("module.runtime.https.enabled").Bool())
+}
+
+// TestOpenAPI_WithExistingHook demonstrates that WithOpenAPIDir composes
+// with the actual hooks shipped by this module. The values hook writes
+// to `some.path.to.field.*` paths that are independent of the schema, so
+// schema defaults and hook output coexist.
+func TestOpenAPI_WithExistingHook(t *testing.T) {
+	hec := framework.NewHookExecutionConfig(t,
+		&pkg.HookConfig{
+			Metadata:     pkg.HookMetadata{Name: "openapi-with-existing-hook"},
+			OnBeforeHelm: &pkg.OrderedConfig{Order: 1},
+		},
+		subfolder.HandlerHookValues,
+		framework.WithOpenAPIDir(openapiDir),
+		framework.WithInitialValues(`{
+            "some": {
+                "path": {
+                    "to": {
+                        "field": {
+                            "someInt": 1,
+                            "array":   [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                        }
+                    }
+                }
+            }
+        }`),
+	)
+	hec.RunHook()
+	require.NoError(t, hec.HookError())
+
+	// Schema defaults made it through.
+	assert.Equal(t, "Disabled", hec.ValuesGet("https.mode").String())
+	assert.True(t, hec.ValuesGet("internal.golangVersions").Exists())
+
+	// And the hook ran: it sets `.some.path.to.field.str` then removes
+	// `.some.path.to.field`, so the resulting value has neither the
+	// original nested object nor the str — the parent was removed last.
+	assert.False(t, hec.ValuesGet("some.path.to.field").Exists(),
+		"values hook removes the parent key as part of its handler")
+}

--- a/examples/example-module/openapi/config-values.yaml
+++ b/examples/example-module/openapi/config-values.yaml
@@ -1,0 +1,56 @@
+type: object
+properties:
+  replicas:
+    type: integer
+    description: |
+      replicas count.
+    default: 1
+  https:
+    type: object
+    x-examples:
+      - mode: CustomCertificate
+        customCertificate:
+          secretName: "foobar"
+      - mode: CertManager
+        certManager:
+          clusterIssuerName: letsencrypt
+    description: |
+      What certificate type to use with frontend and status apps.
+
+      This parameter completely overrides the `global.modules.https` settings.
+    properties:
+      mode:
+        type: string
+        default: "Disabled"
+        description: |
+          The HTTPS usage mode:
+          - `Disabled` — frontend will work over HTTP only;
+          - `CertManager` — frontend will use HTTPS and get a certificate from the clusterissuer defined in the `certManager.clusterIssuerName` parameter.
+          - `CustomCertificate` — frontend will use HTTPS using the certificate from the `d8-system` namespace.
+          - `OnlyInURI` — frontend will work over HTTP (thinking that there is an external HTTPS load balancer in front that terminates HTTPS traffic). All the links in the `user-authn` will be generated using the HTTPS scheme.
+        enum:
+          - "Disabled"
+          - "CertManager"
+          - "CustomCertificate"
+          - "OnlyInURI"
+      certManager:
+        type: object
+        properties:
+          clusterIssuerName:
+            type: string
+            default: "letsencrypt"
+            description: |
+              What ClusterIssuer to use for frontend.
+
+              Currently, `letsencrypt`, `letsencrypt-staging`, `selfsigned` are available. Also, you can define your own.
+      customCertificate:
+        type: object
+        default: {}
+        properties:
+          secretName:
+            type: string
+            description: |
+              The name of the secret in the `d8-system` namespace to use with frontend.
+
+              This secret must have the [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets) format.
+            default: "false"

--- a/examples/example-module/openapi/values.yaml
+++ b/examples/example-module/openapi/values.yaml
@@ -1,0 +1,16 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  internal:
+    type: object
+    default: {}
+    properties:
+      golangVersions:
+        type: array
+        default: []
+        items:
+          type: string
+  registry:
+    type: object
+    description: "System field, overwritten by Deckhouse. Don't use"

--- a/testing/framework/README.md
+++ b/testing/framework/README.md
@@ -76,7 +76,7 @@ metadata:
 | Function | Purpose |
 | --- | --- |
 | `HookExecutionConfigInit(t, cfg, handler, initValues, initConfigValues)` | Deckhouse-compatible constructor. `initValues` / `initConfigValues` accept JSON or YAML; pass `"{}"` if not needed. |
-| `NewHookExecutionConfig(t, cfg, handler, opts...)` | Same, but with explicit `Option`s. Accepts `WithInitialValues`, `WithInitialConfigValues`, `WithSchemeBuilder`, `WithCRD`. |
+| `NewHookExecutionConfig(t, cfg, handler, opts...)` | Same, but with explicit `Option`s. Accepts `WithInitialValues`, `WithInitialConfigValues`, `WithSchemeBuilder`, `WithCRD`, `WithOpenAPIDir`, `WithValuesSchema`, `WithConfigValuesSchema`. |
 
 `t` is a `testing.TB`, so `*testing.T`, sub-tests, and `GinkgoT()` all work.
 
@@ -103,6 +103,37 @@ f.RegisterCRD("acme.io", "v1", "Widget", true)
 ```
 
 `WithSchemeBuilder` is preferred when the CRD has Go types you can import; `WithCRD` / `RegisterCRD` is used to teach the GVR resolver about a kind that lives only in YAML.
+
+### OpenAPI defaults
+
+In production, addon-operator applies defaults from the module's OpenAPI schemas (`openapi/values.yaml` and `openapi/config-values.yaml`) before invoking a hook. The framework can do the same so tests don't drift from real-world behaviour:
+
+```go
+f := framework.NewHookExecutionConfig(t, cfg, handler,
+    framework.WithOpenAPIDir("../openapi"),
+    framework.WithInitialValues(`{"https": {"mode": "CertManager"}}`),
+)
+```
+
+Behaviour:
+
+- `WithOpenAPIDir(dir)` looks for `<dir>/values.yaml` and `<dir>/config-values.yaml`. Whichever ones are present are loaded.
+- For each schema, the framework extracts every `default:` declared in it and uses the result as a baseline values document.
+- Anything passed via `WithInitialValues` / `WithInitialConfigValues` is then deep-merged on top — your test's values always override schema defaults.
+- The `x-extend` extension is honoured. If `values.yaml` declares `x-extend.schema: config-values.yaml`, the values store inherits all defaults from `config-values.yaml` plus its own.
+
+For more granular control use `WithValuesSchema(path)` / `WithConfigValuesSchema(path)` instead — they fail the test if the file is missing.
+
+The lower-level helpers `LoadOpenAPISchema`, `SchemaDefaults`, and `MergeValues` are also exported, which is handy when you want to assemble a full values document outside `NewHookExecutionConfig`:
+
+```go
+schema, err := framework.LoadOpenAPISchema("../openapi/values.yaml")
+require.NoError(t, err)
+defaults := framework.SchemaDefaults(schema)
+merged := framework.MergeValues(defaults, map[string]any{
+    "replicas": 5,
+})
+```
 
 ### Values
 

--- a/testing/framework/config.go
+++ b/testing/framework/config.go
@@ -137,6 +137,25 @@ func NewHookExecutionConfig(t testing.TB, config *pkg.HookConfig, handler HookFu
 		t.Fatalf("framework: parse initial config values: %v", err)
 	}
 
+	// Apply defaults extracted from the OpenAPI schemas, if any. The
+	// user-supplied init values are deep-merged on top so they always
+	// win on conflicts, matching the behaviour Helm/addon-operator
+	// produces in a real environment.
+	if cfg.configValuesSchemaPath != "" {
+		schema, err := LoadOpenAPISchema(cfg.configValuesSchemaPath)
+		if err != nil {
+			t.Fatalf("framework: load config values schema: %v", err)
+		}
+		hec.configValues.values = MergeValues(SchemaDefaults(schema), hec.configValues.values)
+	}
+	if cfg.valuesSchemaPath != "" {
+		schema, err := LoadOpenAPISchema(cfg.valuesSchemaPath)
+		if err != nil {
+			t.Fatalf("framework: load values schema: %v", err)
+		}
+		hec.values.values = MergeValues(SchemaDefaults(schema), hec.values.values)
+	}
+
 	hec.fakeClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme, hec.gvrToListKind)
 
 	for _, crd := range cfg.crds {

--- a/testing/framework/openapi.go
+++ b/testing/framework/openapi.go
@@ -1,0 +1,430 @@
+package framework
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	k8syaml "sigs.k8s.io/yaml"
+)
+
+// OpenAPI helpers for the testing framework.
+//
+// Modules ship two OpenAPI v3 schemas in their `openapi/` directory:
+//
+//   - config-values.yaml — describes the user-controllable module config;
+//   - values.yaml        — extends config-values with system fields
+//     (typically `internal:` and `registry:`).
+//
+// In Deckhouse, addon-operator validates and applies defaults from these
+// schemas before invoking a hook. Hook tests, however, run the handler
+// directly with whatever values the test author passed. That makes it
+// easy to forget that a real environment would have, for example,
+// `https.mode = "Disabled"` set by default — and tests then drift from
+// production behaviour.
+//
+// The helpers here close that gap. They:
+//
+//  1. read an OpenAPI v3 schema from a file path;
+//  2. extract a values document populated with all `default:` values
+//     declared by the schema (recursively, including objects and arrays);
+//  3. merge values supplied by the test on top of those defaults so the
+//     test's values override the schema-provided ones.
+//
+// The functions are intentionally lightweight: they manipulate the schema
+// as a `map[string]any` and do not validate values. For full validation
+// use the validators in `pkg/values/validation` (or the upstream
+// addon-operator implementation).
+
+// LoadOpenAPISchema reads an OpenAPI v3 schema from a YAML or JSON file
+// and returns the parsed document.
+//
+// If the schema document declares the addon-operator x-extend extension,
+// e.g.:
+//
+//	x-extend:
+//	  schema: config-values.yaml
+//
+// LoadOpenAPISchema also loads the referenced schema (resolved relative
+// to the current schema's directory) and merges it as a parent: the
+// parent's `properties`, `patternProperties`, `definitions`, `required`
+// and extensions are folded into the current schema, with the current
+// schema winning on conflicts. This mirrors the behaviour of
+// addon-operator's ExtendTransformer.
+//
+// LoadOpenAPISchema does not resolve `$ref`s.
+func LoadOpenAPISchema(path string) (map[string]any, error) {
+	return loadOpenAPISchemaWithStack(path, nil)
+}
+
+// loadOpenAPISchemaWithStack tracks already-visited paths to break
+// pathological cycles in x-extend chains.
+func loadOpenAPISchemaWithStack(path string, stack []string) (map[string]any, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("openapi: resolve %q: %w", path, err)
+	}
+	for _, prev := range stack {
+		if prev == abs {
+			return nil, fmt.Errorf("openapi: x-extend cycle detected at %q", abs)
+		}
+	}
+
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, fmt.Errorf("openapi: read %q: %w", abs, err)
+	}
+
+	var doc map[string]any
+	if err := k8syaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("openapi: parse %q: %w", abs, err)
+	}
+	if doc == nil {
+		doc = map[string]any{}
+	}
+
+	parentPath, ok := extractExtendSchemaPath(doc)
+	if !ok {
+		return doc, nil
+	}
+
+	parentResolved := parentPath
+	if !filepath.IsAbs(parentResolved) {
+		parentResolved = filepath.Join(filepath.Dir(abs), parentResolved)
+	}
+
+	parent, err := loadOpenAPISchemaWithStack(parentResolved, append(stack, abs))
+	if err != nil {
+		return nil, fmt.Errorf("openapi: load x-extend parent %q: %w", parentPath, err)
+	}
+
+	mergeSchemaWithParent(doc, parent)
+	return doc, nil
+}
+
+// extractExtendSchemaPath reads the optional `x-extend.schema` value
+// from a schema document and returns it.
+func extractExtendSchemaPath(doc map[string]any) (string, bool) {
+	raw, ok := doc["x-extend"]
+	if !ok {
+		return "", false
+	}
+	settings, ok := raw.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	schemaPath, ok := settings["schema"].(string)
+	if !ok || schemaPath == "" {
+		return "", false
+	}
+	return schemaPath, true
+}
+
+// mergeSchemaWithParent folds the parent schema's properties/required/etc.
+// into the current schema, mirroring addon-operator's ExtendTransformer.
+// The current schema wins on conflicts.
+func mergeSchemaWithParent(current, parent map[string]any) {
+	current["properties"] = mergeSchemaMap(current["properties"], parent["properties"])
+	current["patternProperties"] = mergeSchemaMap(current["patternProperties"], parent["patternProperties"])
+	current["definitions"] = mergeSchemaMap(current["definitions"], parent["definitions"])
+	current["required"] = mergeRequired(current["required"], parent["required"])
+
+	if _, has := current["title"]; !has {
+		if title, ok := parent["title"].(string); ok && title != "" {
+			current["title"] = title
+		}
+	}
+	if _, has := current["description"]; !has {
+		if desc, ok := parent["description"].(string); ok && desc != "" {
+			current["description"] = desc
+		}
+	}
+
+	for k, v := range parent {
+		if k == "properties" || k == "patternProperties" || k == "definitions" ||
+			k == "required" || k == "title" || k == "description" || k == "x-extend" {
+			continue
+		}
+		if _, has := current[k]; has {
+			continue
+		}
+		// Only carry over OpenAPI extensions and a small set of known
+		// schema-level keys. We deliberately don't override `type`,
+		// `properties`, etc. that the current schema already declared.
+		if isExtension(k) {
+			current[k] = v
+		}
+	}
+}
+
+// mergeSchemaMap merges two map-shaped schema fields (e.g. `properties`).
+// Keys present in `current` win.
+func mergeSchemaMap(current, parent any) any {
+	out := map[string]any{}
+	if pm, ok := parent.(map[string]any); ok {
+		for k, v := range pm {
+			out[k] = v
+		}
+	}
+	if cm, ok := current.(map[string]any); ok {
+		for k, v := range cm {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		// Preserve "field absent" instead of writing back an empty map.
+		if current == nil && parent == nil {
+			return nil
+		}
+	}
+	return out
+}
+
+// mergeRequired deduplicates two `required:` lists (parent first).
+func mergeRequired(current, parent any) any {
+	pSlice := toStringSlice(parent)
+	cSlice := toStringSlice(current)
+
+	if len(pSlice) == 0 && len(cSlice) == 0 {
+		if current == nil && parent == nil {
+			return nil
+		}
+		return []any{}
+	}
+
+	seen := make(map[string]struct{}, len(pSlice)+len(cSlice))
+	out := make([]any, 0, len(pSlice)+len(cSlice))
+	for _, name := range pSlice {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	for _, name := range cSlice {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+func toStringSlice(v any) []string {
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []any:
+		out := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				out = append(out, str)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func isExtension(key string) bool {
+	return len(key) > 2 && key[0] == 'x' && key[1] == '-'
+}
+
+// SchemaDefaults walks an OpenAPI schema (as returned by LoadOpenAPISchema)
+// and produces a values document populated with the schema's `default:`
+// values.
+//
+// The algorithm mirrors addon-operator's defaulting:
+//
+//   - A property's `default:` (if any) is used as the starting value.
+//   - For object-typed properties, sub-properties' defaults are then
+//     applied for any keys the explicit `default:` left empty.
+//   - For arrays, items' defaults are applied to each existing item of
+//     the explicit `default:` list (item entries themselves are never
+//     synthesised from `items.default`).
+//
+// SchemaDefaults always returns a non-nil map (possibly empty).
+func SchemaDefaults(schema map[string]any) map[string]any {
+	out, _ := schemaDefaults(schema)
+	if out == nil {
+		return map[string]any{}
+	}
+	m, ok := out.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	return m
+}
+
+// schemaDefaults returns (defaultValue, hasDefault). It is recursive and
+// works on any subschema, not just the top-level object.
+func schemaDefaults(schema map[string]any) (any, bool) {
+	if schema == nil {
+		return nil, false
+	}
+
+	rawDef, hasDef := schema["default"]
+	var base any
+	if hasDef {
+		base = deepCopyJSONValue(rawDef)
+	}
+
+	t, _ := schema["type"].(string)
+	_, hasProps := schema["properties"]
+	if t == "" && hasProps {
+		t = "object"
+	}
+
+	switch t {
+	case "object":
+		baseMap, _ := base.(map[string]any)
+		if hasDef && base != nil && baseMap == nil {
+			// The default is a non-object value (e.g. null) for an
+			// object-typed property — leave it alone.
+			return base, true
+		}
+		if baseMap == nil {
+			baseMap = map[string]any{}
+		}
+		props, _ := schema["properties"].(map[string]any)
+		for name, raw := range props {
+			sub, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			subDefault, has := schemaDefaults(sub)
+			if !has {
+				continue
+			}
+			existing, exists := baseMap[name]
+			if !exists {
+				baseMap[name] = subDefault
+				continue
+			}
+			// Both sides exist. If both are maps, the explicit
+			// default's entries win on conflict; otherwise leave
+			// the explicit default untouched.
+			if eMap, eOk := existing.(map[string]any); eOk {
+				if subMap, sOk := subDefault.(map[string]any); sOk {
+					baseMap[name] = MergeValues(subMap, eMap)
+				}
+			}
+		}
+		if hasDef || len(baseMap) > 0 {
+			return baseMap, true
+		}
+		return nil, false
+
+	case "array":
+		// We only recurse into existing array entries (those provided
+		// by the explicit default). We never create new entries from
+		// `items.default` alone.
+		if !hasDef {
+			return nil, false
+		}
+		list, ok := base.([]any)
+		if !ok {
+			return base, true
+		}
+		items, _ := schema["items"].(map[string]any)
+		if items == nil {
+			return list, true
+		}
+		for i, item := range list {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			itemDefaults, has := schemaDefaults(items)
+			if !has {
+				continue
+			}
+			itemMapDefaults, ok := itemDefaults.(map[string]any)
+			if !ok {
+				continue
+			}
+			list[i] = MergeValues(itemMapDefaults, itemMap)
+		}
+		return list, true
+
+	default:
+		if hasDef {
+			return base, true
+		}
+		return nil, false
+	}
+}
+
+// MergeValues deep-merges override into base and returns the result.
+//
+// Object-typed values are merged property-by-property (recursing). For
+// arrays and scalar values the override replaces the base entirely.
+//
+// Neither input is modified.
+//
+// MergeValues is the natural counterpart to SchemaDefaults: combine
+// defaults extracted from a schema with values supplied by the test,
+// letting the test's values win on every conflict.
+func MergeValues(base, override map[string]any) map[string]any {
+	out := deepCopyJSONMap(base)
+	if out == nil {
+		out = map[string]any{}
+	}
+	for k, v := range override {
+		if existing, ok := out[k]; ok {
+			if eMap, eOk := existing.(map[string]any); eOk {
+				if vMap, vOk := v.(map[string]any); vOk {
+					out[k] = MergeValues(eMap, vMap)
+					continue
+				}
+			}
+		}
+		out[k] = deepCopyJSONValue(v)
+	}
+	return out
+}
+
+// deepCopyJSONValue returns a deep copy of a JSON-compatible value.
+// Maps and slices are cloned recursively; other values are returned as-is
+// (they are immutable in JSON semantics).
+func deepCopyJSONValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return deepCopyJSONMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, item := range t {
+			out[i] = deepCopyJSONValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func deepCopyJSONMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = deepCopyJSONValue(v)
+	}
+	return out
+}
+
+// fileExists returns true if path refers to an existing regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false
+		}
+		return false
+	}
+	return !info.IsDir()
+}

--- a/testing/framework/openapi_stub/config-values.yaml
+++ b/testing/framework/openapi_stub/config-values.yaml
@@ -1,0 +1,44 @@
+# Stub config-values OpenAPI schema used by the testing/framework tests.
+# It is intentionally self-contained (does not reference any module's
+# schemas) so the tests do not depend on the example modules.
+type: object
+properties:
+  replicas:
+    type: integer
+    description: |
+      Replica count.
+    default: 1
+  https:
+    type: object
+    description: |
+      HTTPS settings for the module.
+    properties:
+      mode:
+        type: string
+        default: "Disabled"
+        description: HTTPS usage mode.
+        enum:
+          - "Disabled"
+          - "CertManager"
+          - "CustomCertificate"
+      certManager:
+        type: object
+        properties:
+          clusterIssuerName:
+            type: string
+            default: "letsencrypt"
+      customCertificate:
+        type: object
+        default: {}
+        properties:
+          secretName:
+            type: string
+            default: "false"
+  tags:
+    type: array
+    description: |
+      Free-form tags. Defaults to an empty list so hooks can append to it
+      without having to check existence first.
+    default: []
+    items:
+      type: string

--- a/testing/framework/openapi_stub/values.yaml
+++ b/testing/framework/openapi_stub/values.yaml
@@ -1,0 +1,21 @@
+# Stub values OpenAPI schema used by the testing/framework tests.
+# It exercises x-extend: properties from config-values.yaml are inherited
+# at the top level, plus the values-only `internal` and `registry`
+# sections.
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  internal:
+    type: object
+    default: {}
+    properties:
+      golangVersions:
+        type: array
+        default: []
+        items:
+          type: string
+  registry:
+    type: object
+    description: |
+      System field, overwritten by Deckhouse. Not defaulted on purpose.

--- a/testing/framework/openapi_test.go
+++ b/testing/framework/openapi_test.go
@@ -1,0 +1,213 @@
+package framework_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/module-sdk/pkg"
+	"github.com/deckhouse/module-sdk/testing/framework"
+)
+
+// openapiStub points at the self-contained OpenAPI fixtures used by the
+// framework's own tests. Tests must not depend on schemas defined in the
+// example modules — those evolve independently as documentation.
+const openapiStub = "openapi_stub"
+
+// TestSchemaDefaults_FromConfigValues verifies that SchemaDefaults walks
+// an OpenAPI schema and produces a values map containing every `default:`
+// value declared in it (recursively).
+func TestSchemaDefaults_FromConfigValues(t *testing.T) {
+	schema, err := framework.LoadOpenAPISchema(filepath.Join(openapiStub, "config-values.yaml"))
+	require.NoError(t, err)
+
+	defaults := framework.SchemaDefaults(schema)
+
+	assert.EqualValues(t, 1, defaults["replicas"])
+
+	https, _ := defaults["https"].(map[string]any)
+	require.NotNil(t, https)
+	assert.Equal(t, "Disabled", https["mode"])
+
+	cm, _ := https["certManager"].(map[string]any)
+	require.NotNil(t, cm)
+	assert.Equal(t, "letsencrypt", cm["clusterIssuerName"])
+
+	// `customCertificate` declares `default: {}` AND a `secretName`
+	// sub-property with its own default. Our defaulting algorithm must
+	// merge sub-property defaults into the explicit default object.
+	custom, _ := https["customCertificate"].(map[string]any)
+	require.NotNil(t, custom)
+	assert.Equal(t, "false", custom["secretName"])
+
+	// Top-level array default must be preserved as-is.
+	tags, ok := defaults["tags"].([]any)
+	require.True(t, ok, "expected tags to be a slice, got %T", defaults["tags"])
+	assert.Empty(t, tags)
+}
+
+// TestSchemaDefaults_XExtend verifies that values.yaml correctly inherits
+// properties from config-values.yaml when it declares `x-extend`.
+func TestSchemaDefaults_XExtend(t *testing.T) {
+	schema, err := framework.LoadOpenAPISchema(filepath.Join(openapiStub, "values.yaml"))
+	require.NoError(t, err)
+
+	defaults := framework.SchemaDefaults(schema)
+
+	internal, _ := defaults["internal"].(map[string]any)
+	require.NotNil(t, internal, "values.yaml should produce default for internal")
+	versions, _ := internal["golangVersions"].([]any)
+	assert.Empty(t, versions)
+
+	assert.EqualValues(t, 1, defaults["replicas"], "should inherit replicas default from config-values.yaml")
+
+	https, _ := defaults["https"].(map[string]any)
+	require.NotNil(t, https, "should inherit https tree from config-values.yaml")
+	assert.Equal(t, "Disabled", https["mode"])
+
+	// `registry` has no default anywhere in the schema and must not appear.
+	_, hasRegistry := defaults["registry"]
+	assert.False(t, hasRegistry, "registry has no defaults and must not be synthesised")
+}
+
+// TestMergeValues verifies the deep-merge semantics: objects are merged
+// property-by-property, scalars and arrays are replaced.
+func TestMergeValues(t *testing.T) {
+	base := map[string]any{
+		"replicas": 1,
+		"https": map[string]any{
+			"mode": "Disabled",
+			"certManager": map[string]any{
+				"clusterIssuerName": "letsencrypt",
+			},
+		},
+		"tags": []any{"a", "b"},
+	}
+	override := map[string]any{
+		"replicas": 5,
+		"https": map[string]any{
+			"mode": "CertManager",
+		},
+		"tags": []any{"c"},
+	}
+
+	out := framework.MergeValues(base, override)
+
+	assert.EqualValues(t, 5, out["replicas"])
+
+	https, _ := out["https"].(map[string]any)
+	require.NotNil(t, https)
+	assert.Equal(t, "CertManager", https["mode"])
+	cm, _ := https["certManager"].(map[string]any)
+	require.NotNil(t, cm, "untouched nested map should survive merge")
+	assert.Equal(t, "letsencrypt", cm["clusterIssuerName"])
+
+	assert.Equal(t, []any{"c"}, out["tags"], "arrays must be replaced, not concatenated")
+
+	// base should not be mutated.
+	assert.EqualValues(t, 1, base["replicas"])
+	baseHTTPS, _ := base["https"].(map[string]any)
+	assert.Equal(t, "Disabled", baseHTTPS["mode"])
+}
+
+// TestWithOpenAPIDir_ProducesDefaults verifies the framework option:
+// pointing at the openapi_stub/ directory must populate the values store
+// with all defaults declared in the schema, with user-supplied initial
+// values overriding them.
+func TestWithOpenAPIDir_ProducesDefaults(t *testing.T) {
+	cfg := &pkg.HookConfig{Metadata: pkg.HookMetadata{Name: "openapi-defaults"}}
+	handler := func(_ context.Context, _ *pkg.HookInput) error { return nil }
+
+	hec := framework.NewHookExecutionConfig(t, cfg, handler,
+		framework.WithOpenAPIDir(openapiStub),
+		framework.WithInitialValues(`{"https": {"mode": "CertManager"}}`),
+		framework.WithInitialConfigValues(`{"replicas": 7}`),
+	)
+	hec.RunHook()
+	require.NoError(t, hec.HookError())
+
+	assert.EqualValues(t, 7, hec.ConfigValuesGet("replicas").Int(),
+		"user override must win for config values")
+
+	assert.Equal(t, "Disabled", hec.ConfigValuesGet("https.mode").String(),
+		"untouched config-values defaults must remain")
+	assert.Equal(t, "letsencrypt", hec.ConfigValuesGet("https.certManager.clusterIssuerName").String())
+
+	assert.Equal(t, "CertManager", hec.ValuesGet("https.mode").String(),
+		"user override on values must win")
+	assert.Equal(t, "letsencrypt", hec.ValuesGet("https.certManager.clusterIssuerName").String(),
+		"values must inherit defaults from config-values via x-extend")
+
+	assert.True(t, hec.ValuesGet("internal.golangVersions").Exists(),
+		"values.yaml-only defaults must also be present")
+}
+
+// TestWithOpenAPIDir_IgnoresMissingFiles verifies that WithOpenAPIDir is
+// permissive: pointing at a directory that has neither values.yaml nor
+// config-values.yaml must succeed and behave as if the option had not
+// been passed.
+func TestWithOpenAPIDir_IgnoresMissingFiles(t *testing.T) {
+	emptyDir := t.TempDir()
+
+	cfg := &pkg.HookConfig{Metadata: pkg.HookMetadata{Name: "openapi-empty"}}
+	handler := func(_ context.Context, _ *pkg.HookInput) error { return nil }
+
+	hec := framework.NewHookExecutionConfig(t, cfg, handler,
+		framework.WithOpenAPIDir(emptyDir),
+		framework.WithInitialValues(`{"foo": "bar"}`),
+	)
+	hec.RunHook()
+	require.NoError(t, hec.HookError())
+	assert.Equal(t, "bar", hec.ValuesGet("foo").String())
+}
+
+// TestWithValuesSchema_AppliesDefaults verifies the targeted variant:
+// only the values schema is loaded; config-values are left untouched.
+func TestWithValuesSchema_AppliesDefaults(t *testing.T) {
+	cfg := &pkg.HookConfig{Metadata: pkg.HookMetadata{Name: "openapi-values-only"}}
+	handler := func(_ context.Context, _ *pkg.HookInput) error { return nil }
+
+	hec := framework.NewHookExecutionConfig(t, cfg, handler,
+		framework.WithValuesSchema(filepath.Join(openapiStub, "values.yaml")),
+	)
+	hec.RunHook()
+	require.NoError(t, hec.HookError())
+
+	assert.Equal(t, "Disabled", hec.ValuesGet("https.mode").String())
+	// config values are untouched.
+	assert.False(t, hec.ConfigValuesGet("https.mode").Exists())
+}
+
+// TestWithValuesSchema_MissingFile fails fast.
+func TestWithValuesSchema_MissingFile(t *testing.T) {
+	cfg := &pkg.HookConfig{Metadata: pkg.HookMetadata{Name: "openapi-missing"}}
+	handler := func(_ context.Context, _ *pkg.HookInput) error { return nil }
+
+	tt := &captureT{TB: t}
+	defer func() { _ = recover() }()
+
+	framework.NewHookExecutionConfig(tt, cfg, handler,
+		framework.WithValuesSchema("/this/path/does/not/exist.yaml"),
+	)
+
+	assert.True(t, tt.failed, "missing schema file should fail the test")
+}
+
+// captureT is a testing.TB that records Fatalf rather than killing the
+// whole goroutine — used to assert that the framework reports errors.
+type captureT struct {
+	testing.TB
+	failed bool
+}
+
+func (c *captureT) Fatalf(format string, args ...any) {
+	c.failed = true
+	// Don't actually call FailNow on the parent; we want the test that
+	// uses captureT to keep running and assert on c.failed.
+	panic("captureT: " + format)
+}
+
+func (c *captureT) Errorf(format string, args ...any) { c.failed = true }

--- a/testing/framework/options.go
+++ b/testing/framework/options.go
@@ -1,6 +1,10 @@
 package framework
 
-import "k8s.io/apimachinery/pkg/runtime"
+import (
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 // Option configures a HookExecutionConfig at construction time.
 type Option interface {
@@ -13,10 +17,12 @@ func (f optionFunc) apply(o *execOptions) { f(o) }
 
 // execOptions holds parsed framework options.
 type execOptions struct {
-	initValues          string
-	initConfigValues    string
-	extraSchemeBuilders []runtime.SchemeBuilder
-	crds                []customCRD
+	initValues             string
+	initConfigValues       string
+	valuesSchemaPath       string
+	configValuesSchemaPath string
+	extraSchemeBuilders    []runtime.SchemeBuilder
+	crds                   []customCRD
 }
 
 type customCRD struct {
@@ -58,5 +64,60 @@ func WithCRD(group, version, kind string, namespaced bool) Option {
 		o.crds = append(o.crds, customCRD{
 			group: group, version: version, kind: kind, namespaced: namespaced,
 		})
+	})
+}
+
+// WithValuesSchema reads an OpenAPI v3 schema from the given file path,
+// extracts a values document populated with all `default:` values, and
+// uses it as the baseline for the framework's `Values`. Anything passed
+// via WithInitialValues (or HookExecutionConfigInit's initValues) is then
+// deep-merged on top, so test-supplied values override schema defaults.
+//
+// The schema may use the addon-operator `x-extend` extension to inherit
+// `properties` / `required` from a sibling schema (typically
+// config-values.yaml). See LoadOpenAPISchema for details.
+//
+// Construction fails the test (via testing.TB.Fatalf) if the file is
+// missing or malformed. Use WithOpenAPIDir if you want missing files to
+// be silently ignored.
+func WithValuesSchema(path string) Option {
+	return optionFunc(func(o *execOptions) {
+		o.valuesSchemaPath = path
+	})
+}
+
+// WithConfigValuesSchema does the same as WithValuesSchema for the
+// module's config values schema (typically `openapi/config-values.yaml`).
+func WithConfigValuesSchema(path string) Option {
+	return optionFunc(func(o *execOptions) {
+		o.configValuesSchemaPath = path
+	})
+}
+
+// WithOpenAPIDir is a convenience wrapper that points the framework at a
+// directory containing the standard module OpenAPI files:
+//
+//	<dir>/values.yaml
+//	<dir>/config-values.yaml
+//
+// Either file may be absent. Whichever ones are present are loaded and
+// their defaults are merged under any test-supplied values.
+//
+// Example:
+//
+//	hec := framework.NewHookExecutionConfig(t, cfg, handler,
+//	    framework.WithOpenAPIDir("../openapi"),
+//	    framework.WithInitialValues(`{"https": {"mode": "CertManager"}}`),
+//	)
+func WithOpenAPIDir(dir string) Option {
+	return optionFunc(func(o *execOptions) {
+		valuesPath := filepath.Join(dir, "values.yaml")
+		if fileExists(valuesPath) {
+			o.valuesSchemaPath = valuesPath
+		}
+		configPath := filepath.Join(dir, "config-values.yaml")
+		if fileExists(configPath) {
+			o.configValuesSchemaPath = configPath
+		}
 	})
 }


### PR DESCRIPTION
Adds OpenAPI schema support to the functional testing framework so hook tests start from the same values state addon-operator produces in production.

**What's included:**

- `LoadOpenAPISchema` — reads an OpenAPI v3 YAML schema, resolves the `x-extend` parent chain (same semantics as addon-operator's `ExtendTransformer`)
- `SchemaDefaults` — walks a loaded schema and extracts a values document with all `default:` values applied recursively (objects, arrays, nested sub-properties)
- `MergeValues` — deep-merges two values maps with override-wins semantics (objects recursed, scalars/arrays replaced)
- Three new `Option`s for `NewHookExecutionConfig`:
  - `WithOpenAPIDir(dir)` — loads `<dir>/values.yaml` and `<dir>/config-values.yaml` if present, silently ignores absent files
  - `WithValuesSchema(path)` / `WithConfigValuesSchema(path)` — fail-fast targeted variants
- Self-contained stub schemas in `testing/framework/openapi_stub/` so framework tests don't depend on example-module files
- Three new framework tests in `examples/example-module/hooks/subfolder/openapi_framework_test.go` covering defaults, user overrides, and composing with an existing hook handler