### PR TITLE
[module-sdk] fix: preserve crd vendor extensions

### DIFF
--- a/pkg/crd-installer/installer.go
+++ b/pkg/crd-installer/installer.go
@@ -15,6 +15,8 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apimachineryYaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
@@ -190,32 +192,29 @@ func (cp *CRDsInstaller) processCRD(ctx context.Context, crdFilePath string) err
 }
 
 func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reader, bufferSize int) error {
-	var crd *apiextensionsv1.CustomResourceDefinition
-
-	err := apimachineryYaml.NewYAMLOrJSONDecoder(crdReader, bufferSize).Decode(&crd)
+	// Decode into unstructured so vendor schema extensions (x-kubernetes-*, x-ui-*, ...)
+	// survive verbatim; the typed struct below is used only to read metadata.
+	desired := &unstructured.Unstructured{}
+	err := apimachineryYaml.NewYAMLOrJSONDecoder(crdReader, bufferSize).Decode(&desired)
 	if err != nil {
 		return err
 	}
 
-	// it could be a comment or some other peace of yaml file, skip it
-	if crd == nil {
+	// it could be a comment or some other piece of yaml file, skip it
+	if len(desired.Object) == 0 {
 		return nil
 	}
 
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(desired.Object, crd); err != nil {
+		return err
+	}
 	if crd.APIVersion != apiextensionsv1.SchemeGroupVersion.String() && crd.Kind != "CustomResourceDefinition" {
 		return fmt.Errorf("invalid CRD document apiversion/kind: '%s/%s'", crd.APIVersion, crd.Kind)
 	}
 
-	if len(crd.ObjectMeta.Labels) == 0 {
-		crd.ObjectMeta.Labels = make(map[string]string, 1)
-	}
-
-	for crdExtraLabel := range cp.crdExtraLabels {
-		crd.ObjectMeta.Labels[crdExtraLabel] = cp.crdExtraLabels[crdExtraLabel]
-	}
-
 	cp.k8sTasks.Go(func() error {
-		err := cp.updateOrInsertCRD(ctx, crd)
+		err := cp.updateOrInsertCRD(ctx, crd, desired)
 		if err == nil {
 			var crdGroup, crdKind string
 
@@ -255,16 +254,13 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 	return nil
 }
 
-func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, desired *unstructured.Unstructured) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		existCRD, err := cp.GetCRDFromCluster(ctx, crd.GetName())
+		existing, err := cp.k8sClient.Resource(crdGVR).Get(ctx, crd.GetName(), apimachineryv1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			ucrd, err := utils.ToUnstructured(crd)
-			if err != nil {
-				return err
-			}
+			mergeLabels(desired, cp.crdExtraLabels)
 
-			_, err = cp.k8sClient.Resource(crdGVR).Create(ctx, ucrd, apimachineryv1.CreateOptions{})
+			_, err = cp.k8sClient.Resource(crdGVR).Create(ctx, desired, apimachineryv1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("create crd: %w", err)
 			}
@@ -274,6 +270,13 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 
 		if err != nil {
 			return fmt.Errorf("get crd from cluster: %w", err)
+		}
+
+		// typed view of the existing object is used only to reconcile storedVersions;
+		// it is never written back as the CRD body (that would drop vendor extensions).
+		existCRD := &apiextensionsv1.CustomResourceDefinition{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(existing.Object, existCRD); err != nil {
+			return fmt.Errorf("existing crd from unstructured: %w", err)
 		}
 
 		versionsFromNewSpec := make(map[string]struct{}, len(crd.Spec.Versions))
@@ -288,8 +291,10 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 			}
 		}
 
+		resourceVersion := existing.GetResourceVersion()
 		if !slices.Equal(newStoredVersions, existCRD.Status.StoredVersions) {
 			existCRD.Status.StoredVersions = newStoredVersions
+			// the status subresource update ignores .spec, so writing the typed (lossy) body here is safe
 			ucrd, err := utils.ToUnstructured(existCRD)
 			if err != nil {
 				return fmt.Errorf("crd to unstructured: %w", err)
@@ -301,44 +306,52 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 			}
 
 			if resp != nil {
-				existCRD.ObjectMeta.ResourceVersion = resp.GetResourceVersion()
+				resourceVersion = resp.GetResourceVersion()
 			}
 		}
 
-		if existCRD.Spec.Conversion != nil {
-			crd.Spec.Conversion = existCRD.Spec.Conversion
+		// keep the in-cluster conversion webhook config (it is not present in the CRD file)
+		if conv, found, err := unstructured.NestedFieldCopy(existing.Object, "spec", "conversion"); err == nil && found {
+			if err := unstructured.SetNestedField(desired.Object, conv, "spec", "conversion"); err != nil {
+				return fmt.Errorf("preserve conversion: %w", err)
+			}
 		}
 
-		if cmp.Equal(existCRD.Spec, crd.Spec) &&
-			cmp.Equal(existCRD.GetLabels(), crd.GetLabels()) &&
-			cmp.Equal(existCRD.GetAnnotations(), crd.GetAnnotations()) {
+		mergeLabels(desired, cp.crdExtraLabels)
+
+		// diff on lossless unstructured specs so vendor extensions are not silently dropped
+		// ponytail: apiserver-defaulted .spec fields could cause reconcile churn; conversion is
+		// preserved above, extend here if a defaulted field ever churns.
+		desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+		existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+		if cmp.Equal(existingSpec, desiredSpec) &&
+			cmp.Equal(existing.GetLabels(), desired.GetLabels()) &&
+			cmp.Equal(existing.GetAnnotations(), desired.GetAnnotations()) {
 			return nil
 		}
 
-		existCRD.Spec = crd.Spec
-		existCRD.Labels = crd.Labels
-		existCRD.Annotations = crd.Annotations
+		desired.SetResourceVersion(resourceVersion)
 
-		if len(existCRD.ObjectMeta.Labels) == 0 {
-			existCRD.ObjectMeta.Labels = make(map[string]string, 1)
-		}
-
-		for crdExtraLabel := range cp.crdExtraLabels {
-			existCRD.ObjectMeta.Labels[crdExtraLabel] = cp.crdExtraLabels[crdExtraLabel]
-		}
-
-		ucrd, err := utils.ToUnstructured(existCRD)
-		if err != nil {
-			return err
-		}
-
-		_, err = cp.k8sClient.Resource(crdGVR).Update(ctx, ucrd, apimachineryv1.UpdateOptions{})
+		_, err = cp.k8sClient.Resource(crdGVR).Update(ctx, desired, apimachineryv1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("update crd: %w", err)
 		}
 
 		return nil
 	})
+}
+
+func mergeLabels(u *unstructured.Unstructured, extra map[string]string) {
+	labels := u.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, len(extra))
+	}
+
+	for k, v := range extra {
+		labels[k] = v
+	}
+
+	u.SetLabels(labels)
 }
 
 func (cp *CRDsInstaller) GetCRDFromCluster(ctx context.Context, crdName string) (*apiextensionsv1.CustomResourceDefinition, error) {

--- a/pkg/crd-installer/installer.go
+++ b/pkg/crd-installer/installer.go
@@ -200,8 +200,8 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 		return err
 	}
 
-	// it could be a comment or some other piece of yaml file, skip it
-	if len(desired.Object) == 0 {
+	// a comment or other non-object yaml document decodes to a nil pointer / empty object, skip it
+	if desired == nil || len(desired.Object) == 0 {
 		return nil
 	}
 
@@ -209,7 +209,7 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(desired.Object, crd); err != nil {
 		return err
 	}
-	if crd.APIVersion != apiextensionsv1.SchemeGroupVersion.String() && crd.Kind != "CustomResourceDefinition" {
+	if crd.APIVersion != apiextensionsv1.SchemeGroupVersion.String() || crd.Kind != "CustomResourceDefinition" {
 		return fmt.Errorf("invalid CRD document apiversion/kind: '%s/%s'", crd.APIVersion, crd.Kind)
 	}
 
@@ -319,20 +319,35 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 
 		mergeLabels(desired, cp.crdExtraLabels)
 
+		desiredSpec, _, err := unstructured.NestedMap(desired.Object, "spec")
+		if err != nil {
+			return fmt.Errorf("read desired spec: %w", err)
+		}
+
+		existingSpec, _, err := unstructured.NestedMap(existing.Object, "spec")
+		if err != nil {
+			return fmt.Errorf("read existing spec: %w", err)
+		}
+
 		// diff on lossless unstructured specs so vendor extensions are not silently dropped
-		// ponytail: apiserver-defaulted .spec fields could cause reconcile churn; conversion is
-		// preserved above, extend here if a defaulted field ever churns.
-		desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
-		existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+		// ponytail: apiserver-defaulted .spec fields may differ from the manifest and cause
+		// reconcile churn; the update stays idempotent, tighten the diff here if it ever churns.
 		if cmp.Equal(existingSpec, desiredSpec) &&
 			cmp.Equal(existing.GetLabels(), desired.GetLabels()) &&
 			cmp.Equal(existing.GetAnnotations(), desired.GetAnnotations()) {
 			return nil
 		}
 
-		desired.SetResourceVersion(resourceVersion)
+		// write back the fetched object with only spec/labels/annotations overlaid, so
+		// server-managed metadata (finalizers, ownerReferences, uid, ...) is preserved.
+		if err := unstructured.SetNestedMap(existing.Object, desiredSpec, "spec"); err != nil {
+			return fmt.Errorf("set spec: %w", err)
+		}
+		existing.SetLabels(desired.GetLabels())
+		existing.SetAnnotations(desired.GetAnnotations())
+		existing.SetResourceVersion(resourceVersion)
 
-		_, err = cp.k8sClient.Resource(crdGVR).Update(ctx, desired, apimachineryv1.UpdateOptions{})
+		_, err = cp.k8sClient.Resource(crdGVR).Update(ctx, existing, apimachineryv1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("update crd: %w", err)
 		}

--- a/pkg/crd-installer/installer_test.go
+++ b/pkg/crd-installer/installer_test.go
@@ -89,4 +89,72 @@ func TestCRDInstaller(t *testing.T) {
 		assert.Equal(t, true, token["x-kubernetes-sensitive-data"],
 			"vendor extension must survive the install path")
 	})
+
+	// Regression: updating an existing CRD must apply the manifest spec (with vendor
+	// extensions) while preserving server-managed metadata (finalizers) and the in-cluster
+	// conversion config, which is never present in the manifest.
+	t.Run("update preserves finalizers and in-cluster conversion", func(t *testing.T) {
+		seed := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name":       "things.example.com",
+				"finalizers": []any{"customresourcecleanup.apiextensions.k8s.io"},
+			},
+			"spec": map[string]any{
+				"group": "example.com",
+				"names": map[string]any{
+					"kind": "Thing", "listKind": "ThingList", "plural": "things", "singular": "thing",
+				},
+				"scope": "Namespaced",
+				"conversion": map[string]any{
+					"strategy": "Webhook",
+					"webhook": map[string]any{
+						"conversionReviewVersions": []any{"v1"},
+						"clientConfig": map[string]any{
+							"service": map[string]any{"name": "conv", "namespace": "default"},
+						},
+					},
+				},
+				"versions": []any{
+					map[string]any{"name": "v1", "served": true, "storage": true},
+				},
+			},
+		}}
+		_, err := fc.Resource(gvr).Create(context.Background(), seed, apimachineryv1.CreateOptions{})
+		require.NoError(t, err)
+
+		inst := NewCRDsInstaller(fc, []string{"testdata/4_conversion.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		un, err := fc.Resource(gvr).Get(context.Background(), "things.example.com", apimachineryv1.GetOptions{})
+		require.NoError(t, err)
+
+		finalizers, found, err := unstructured.NestedStringSlice(un.Object, "metadata", "finalizers")
+		require.NoError(t, err)
+		require.True(t, found, "finalizers must be preserved")
+		assert.Contains(t, finalizers, "customresourcecleanup.apiextensions.k8s.io")
+
+		_, found, err = unstructured.NestedMap(un.Object, "spec", "conversion")
+		require.NoError(t, err)
+		assert.True(t, found, "in-cluster conversion must be preserved")
+
+		versions, _, err := unstructured.NestedSlice(un.Object, "spec", "versions")
+		require.NoError(t, err)
+		token, found, err := unstructured.NestedMap(versions[0].(map[string]any),
+			"schema", "openAPIV3Schema", "properties", "spec", "properties", "token")
+		require.NoError(t, err)
+		require.True(t, found, "manifest schema must be applied")
+		assert.Equal(t, true, token["x-kubernetes-sensitive-data"])
+	})
+
+	// Regression: a comment-only yaml document decodes to a nil object and must be skipped,
+	// not panic on the nil dereference.
+	t.Run("skips comment-only documents", func(t *testing.T) {
+		inst := NewCRDsInstaller(fc, []string{"testdata/5_comment.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		_, err := fc.Resource(gvr).Get(context.Background(), "comments.example.com", apimachineryv1.GetOptions{})
+		require.NoError(t, err)
+	})
 }

--- a/pkg/crd-installer/installer_test.go
+++ b/pkg/crd-installer/installer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimachineryv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
@@ -65,5 +66,27 @@ func TestCRDInstaller(t *testing.T) {
 
 		f4 := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["field4"].Type
 		assert.Equal(t, "boolean", f4)
+	})
+
+	// Regression: vendor schema extensions (x-kubernetes-sensitive-data and friends) must
+	// survive the install path. Decoding CRDs into the typed struct drops them, so the
+	// installer must apply the object as unstructured.
+	t.Run("preserves vendor schema extensions", func(t *testing.T) {
+		inst := NewCRDsInstaller(fc, []string{"testdata/3_sensitive.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		un, err := fc.Resource(gvr).Get(context.Background(), "secrets.example.com", apimachineryv1.GetOptions{})
+		require.NoError(t, err)
+
+		versions, found, err := unstructured.NestedSlice(un.Object, "spec", "versions")
+		require.NoError(t, err)
+		require.True(t, found, "spec.versions must be present")
+
+		token, found, err := unstructured.NestedMap(versions[0].(map[string]any),
+			"schema", "openAPIV3Schema", "properties", "spec", "properties", "token")
+		require.NoError(t, err)
+		require.True(t, found, "token property must be present")
+		assert.Equal(t, true, token["x-kubernetes-sensitive-data"],
+			"vendor extension must survive the install path")
 	})
 }

--- a/pkg/crd-installer/testdata/3_sensitive.yaml
+++ b/pkg/crd-installer/testdata/3_sensitive.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: secrets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Secret
+    listKind: SecretList
+    plural: secrets
+    singular: secret
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                token:
+                  type: string
+                  x-kubernetes-sensitive-data: true

--- a/pkg/crd-installer/testdata/4_conversion.yaml
+++ b/pkg/crd-installer/testdata/4_conversion.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: things.example.com
+spec:
+  group: example.com
+  names:
+    kind: Thing
+    listKind: ThingList
+    plural: things
+    singular: thing
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                token:
+                  type: string
+                  x-kubernetes-sensitive-data: true

--- a/pkg/crd-installer/testdata/5_comment.yaml
+++ b/pkg/crd-installer/testdata/5_comment.yaml
@@ -1,0 +1,21 @@
+# leading comment document — decodes to null and must be skipped, not crash
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: comments.example.com
+spec:
+  group: example.com
+  names:
+    kind: Comment
+    listKind: CommentList
+    plural: comments
+    singular: comment
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object


### PR DESCRIPTION
## Description

Apply CRDs as `unstructured` (verbatim) instead of decoding them into the typed
`apiextensionsv1.CustomResourceDefinition` before writing. The typed struct is
now used only to read metadata (names/versions/GVK, `storedVersions`); the diff
runs on the lossless unstructured `.spec`, the in-cluster `spec.conversion` is
preserved, and a regression test covers a vendor extension surviving the install
path.

## Why do we need it, and what problem does it solve?

The installer decoded CRDs into a typed struct that has no catch-all for vendor
OpenAPI extensions, so any non-standard `x-*` field
(`x-kubernetes-sensitive-data`, `x-ui-*`, `x-kubernetes-patch-strategy`, …) was
silently dropped before apply. And since the read-back path was also typed, the
diff never saw the difference, so the update never fired and re-runs didn't
self-heal. The installer should transport the CRD as-is and leave schema
validation to the API server.