### PR TITLE
[module-sdk] warn not error on missing certificate secret

### DIFF
--- a/common-hooks/copy-custom-certificate/hook.go
+++ b/common-hooks/copy-custom-certificate/hook.go
@@ -18,7 +18,6 @@ package copycustomcertificate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,10 +65,10 @@ func RegisterHook(moduleName string) bool {
 				JqFilter: JQFilterCustomCertificate,
 			},
 		},
-	}, copyCustomCertificatesHandler(moduleName))
+	}, CopyCustomCertificatesHandler(moduleName))
 }
 
-func copyCustomCertificatesHandler(moduleName string) func(ctx context.Context, input *pkg.HookInput) error {
+func CopyCustomCertificatesHandler(moduleName string) func(ctx context.Context, input *pkg.HookInput) error {
 	return func(_ context.Context, input *pkg.HookInput) error {
 		certs, err := objectpatch.UnmarshalToStruct[certificate.Certificate](input.Snapshots, snapshotKey)
 		if err != nil {
@@ -109,7 +108,9 @@ func copyCustomCertificatesHandler(moduleName string) func(ctx context.Context, 
 
 		cert, ok := customCertificates[secretName]
 		if !ok {
-			return errors.New("custom certificate secret name is configured, but secret with this name '" + secretName + "' doesn't exist")
+			input.Logger.Warn("custom certificate secret name is configured, but secret with this name doesn't exist", "secret_name", secretName)
+			input.Values.Set(valuesPath, certValues{CA: "<none>", TLSKey: "<none>", TLSCert: "<none>"})
+			return nil
 		}
 
 		input.Values.Set(valuesPath, certValues{

--- a/common-hooks/copy-custom-certificate/hook_test.go
+++ b/common-hooks/copy-custom-certificate/hook_test.go
@@ -22,10 +22,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	copycustomcertificate "github.com/deckhouse/module-sdk/common-hooks/copy-custom-certificate"
 	tlscertificate "github.com/deckhouse/module-sdk/common-hooks/tls-certificate"
+	"github.com/deckhouse/module-sdk/pkg"
 	"github.com/deckhouse/module-sdk/pkg/certificate"
+	"github.com/deckhouse/module-sdk/testing/framework"
 	"github.com/deckhouse/module-sdk/testing/helpers"
 )
 
@@ -91,4 +94,158 @@ func TestJQFilterApplyCertificateSecret_ParsesClientCertificate(t *testing.T) {
 	assert.Equal(t, "some-cert", auth.Name)
 	assert.Equal(t, "some-key", string(auth.Key))
 	assert.Equal(t, "some-crt", string(auth.Cert))
+}
+
+func TestHandler_SecretNotFound_ReturnsWarningNotError(t *testing.T) {
+	cfg := &pkg.HookConfig{
+		OnBeforeHelm: &pkg.OrderedConfig{Order: 10},
+		Kubernetes: []pkg.KubernetesConfig{
+			{
+				Name:       "custom_certificates",
+				APIVersion: "v1",
+				Kind:       "Secret",
+				NamespaceSelector: &pkg.NamespaceSelector{
+					NameSelector: &pkg.NameSelector{
+						MatchNames: []string{"d8-system"},
+					},
+				},
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "owner",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"helm"},
+						},
+					},
+				},
+				JqFilter: copycustomcertificate.JQFilterCustomCertificate,
+			},
+		},
+	}
+
+	handler := copycustomcertificate.CopyCustomCertificatesHandler("testmodule")
+	hec := framework.HookExecutionConfigInit(t, cfg, handler, `{}`, `{}`)
+
+	hec.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: other-cert
+  namespace: d8-system
+  labels:
+    owner: deckhouse
+data:
+  tls.crt: Q1JUQ1JUQ1JU
+  tls.key: S0VZS0VZS0VZ
+type: kubernetes.io/tls
+`)
+
+	hec.ValuesSet("testmodule.https.mode", "CustomCertificate")
+	hec.ValuesSet("testmodule.https.customCertificate.secretName", "missing-cert")
+
+	hec.RunHook()
+
+	require.NoError(t, hec.HookError())
+
+	assert.Equal(t, "<none>", hec.ValuesGet("testmodule.internal.customCertificateData.ca\\.crt").String())
+	assert.Equal(t, "<none>", hec.ValuesGet("testmodule.internal.customCertificateData.tls\\.key").String())
+	assert.Equal(t, "<none>", hec.ValuesGet("testmodule.internal.customCertificateData.tls\\.crt").String())
+}
+
+func TestHandler_SecretExists_SetsValues(t *testing.T) {
+	cfg := &pkg.HookConfig{
+		OnBeforeHelm: &pkg.OrderedConfig{Order: 10},
+		Kubernetes: []pkg.KubernetesConfig{
+			{
+				Name:       "custom_certificates",
+				APIVersion: "v1",
+				Kind:       "Secret",
+				NamespaceSelector: &pkg.NamespaceSelector{
+					NameSelector: &pkg.NameSelector{
+						MatchNames: []string{"d8-system"},
+					},
+				},
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "owner",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"helm"},
+						},
+					},
+				},
+				JqFilter: copycustomcertificate.JQFilterCustomCertificate,
+			},
+		},
+	}
+
+	handler := copycustomcertificate.CopyCustomCertificatesHandler("testmodule")
+	hec := framework.HookExecutionConfigInit(t, cfg, handler, `{}`, `{}`)
+
+	hec.KubeStateSet(`
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-cert
+  namespace: d8-system
+  labels:
+    owner: deckhouse
+data:
+  tls.crt: Q1JUQ1JUQ1JU
+  tls.key: S0VZS0VZS0VZ
+  ca.crt: Q0FDQUNBQ0E=
+type: kubernetes.io/tls
+`)
+
+	hec.ValuesSet("testmodule.https.mode", "CustomCertificate")
+	hec.ValuesSet("testmodule.https.customCertificate.secretName", "my-cert")
+
+	hec.RunHook()
+
+	require.NoError(t, hec.HookError())
+
+	assert.Equal(t, "CACACACA", hec.ValuesGet("testmodule.internal.customCertificateData.ca\\.crt").String())
+	assert.Equal(t, "KEYKEYKEY", hec.ValuesGet("testmodule.internal.customCertificateData.tls\\.key").String())
+	assert.Equal(t, "CRTCRTCRT", hec.ValuesGet("testmodule.internal.customCertificateData.tls\\.crt").String())
+}
+
+func TestHandler_NonCustomCertificateMode_RemovesValues(t *testing.T) {
+	cfg := &pkg.HookConfig{
+		OnBeforeHelm: &pkg.OrderedConfig{Order: 10},
+		Kubernetes: []pkg.KubernetesConfig{
+			{
+				Name:       "custom_certificates",
+				APIVersion: "v1",
+				Kind:       "Secret",
+				NamespaceSelector: &pkg.NamespaceSelector{
+					NameSelector: &pkg.NameSelector{
+						MatchNames: []string{"d8-system"},
+					},
+				},
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "owner",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"helm"},
+						},
+					},
+				},
+				JqFilter: copycustomcertificate.JQFilterCustomCertificate,
+			},
+		},
+	}
+
+	handler := copycustomcertificate.CopyCustomCertificatesHandler("testmodule")
+	hec := framework.HookExecutionConfigInit(t, cfg, handler, `{}`, `{}`)
+
+	hec.KubeStateSet(``)
+	hec.ValuesSet("testmodule.https.mode", "CertManager")
+
+	hec.RunHook()
+
+	require.NoError(t, hec.HookError())
+	assert.False(t, hec.ValuesGet("testmodule.internal.customCertificateData").Exists())
 }


### PR DESCRIPTION
## Summary

- **Fix regression in copy-custom-certificate hook**: when the configured `secretName` does not exist in the cluster, the hook now logs a `Warn` and sets placeholder values (`"<none>"`) instead of returning a hard error.
- **Why**: in the original `go_lib` implementation this was a warning with fallback, but the module-sdk port incorrectly changed it to `errors.New()` — causing infinite hook retries that block the parallel queue and prevent other modules from starting.
- **Affected files**: `common-hooks/copy-custom-certificate/hook.go`, `common-hooks/copy-custom-certificate/hook_internal_test.go`.

## Context

When a user configures `https.mode: CustomCertificate` with a `secretName`, the secret might temporarily not exist (cert-manager not yet created, rotation in progress, etc.). The original `go_lib` hook handled this gracefully — warn + fallback values + continue. The module-sdk version returned an error, which caused:

- Hook failures with `failures 2316` (endless retries)
- Blocked parallel queue — other hooks and modules stuck
- Certificate not distributed across namespaces

This fix aligns module-sdk behaviour with the original go_lib implementation.

## Example

**Before** (broken):
```
ModuleHookRun:...:custom_certificates:OperatorStartup:failures 2316:
module hook failed: custom certificate secret name is configured,
but secret with this name 'ngkcore-com-wildcard-tls' doesn't exist
```
→ queue status: `sleep after fail`, other modules blocked.

**After** (fixed):
```
WARN: custom certificate secret name is configured, but secret with this name doesn't exist secret_name=ngkcore-com-wildcard-tls
```
→ queue status: `sleep`, values set to `<none>` placeholders, other modules proceed normally.