### PR TITLE
[module-sdk] fix: prevent CRD update churn and prune unknown extensions

### DIFF
--- a/pkg/crd-installer/installer.go
+++ b/pkg/crd-installer/installer.go
@@ -165,6 +165,8 @@ func (cp *CRDsInstaller) processCRD(ctx context.Context, crdFilePath string) err
 
 	crdReader := apimachineryYaml.NewDocumentDecoder(crdFileReader)
 
+	var errs error
+
 	for {
 		n, err := crdReader.Read(cp.buffer)
 		if err != nil {
@@ -183,13 +185,14 @@ func (cp *CRDsInstaller) processCRD(ctx context.Context, crdFilePath string) err
 
 		rd := bytes.NewReader(data)
 
-		err = cp.putCRDToCluster(ctx, rd, n)
-		if err != nil {
-			return err
+		// one bad document must not skip the rest of the file: the documents after it are
+		// unrelated CRDs, and skipping them silently leaves the module without them
+		if err := cp.putCRDToCluster(ctx, rd, n); err != nil {
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	return nil
+	return errs
 }
 
 func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reader, bufferSize int) error {
@@ -214,8 +217,11 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 		return fmt.Errorf("invalid CRD document apiversion/kind: '%s/%s'", crd.APIVersion, crd.Kind)
 	}
 
-	desired, err = sanitize(crd, desired.Object)
-	if err != nil {
+	if err := applyServerDefaults(crd, desired); err != nil {
+		return fmt.Errorf("default %s: %w", crd.Name, err)
+	}
+
+	if err := sanitize(desired); err != nil {
 		return fmt.Errorf("sanitize %s: %w", crd.Name, err)
 	}
 
@@ -260,97 +266,89 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 	return nil
 }
 
-// sanitize reduces the CRD document to the fields the apiserver actually knows.
+// sanitize drops the schema keys the apiserver does not know from the CRD document.
 //
-// Everything else — x-doc-examples and friends, plus keys that look official but are
-// not, like x-kubernetes-immutable — is dropped here instead of being sent. The
-// apiserver prunes them anyway, after logging one "unknown field" warning per
-// occurrence, and because it prunes them the stored spec could never equal the desired
-// one, so every run issued a pointless Update.
+// x-doc-examples and friends, plus keys that look official but are not, like
+// x-kubernetes-immutable, are removed here instead of being sent. The apiserver prunes
+// them anyway, after logging one "unknown field" warning per occurrence, and because it
+// prunes them the stored spec could never equal the desired one, so every run issued a
+// pointless Update.
 //
-// The typed CRD is that pruned document already, at every level. The single exception
-// is x-kubernetes-sensitive-data, which apiextensionsv1 does not model but the Deckhouse
-// apiserver does, so each version schema is re-decoded through the fork in
-// pkg/crd-installer/openapi that carries it.
-func sanitize(crd *apiextensionsv1.CustomResourceDefinition, raw map[string]any) (*unstructured.Unstructured, error) {
-	clean, err := utils.ToUnstructured(crd)
-	if err != nil {
-		return nil, fmt.Errorf("crd to unstructured: %w", err)
+// Only the version schemas are rewritten; the rest of the document is passed through
+// untouched. Rebuilding it from apiextensionsv1.CustomResourceDefinition instead would
+// pin the installer to the CRD fields of the apiextensions-apiserver it was compiled
+// against, and silently strip anything a newer or patched apiserver understands.
+func sanitize(desired *unstructured.Unstructured) error {
+	versions, ok := nestedValue(desired.Object, "spec", "versions").([]any)
+	if !ok {
+		// no versions, or not a list: let the apiserver reject the document
+		return nil
 	}
 
-	cleanVersions, found, err := unstructured.NestedSlice(clean.Object, "spec", "versions")
-	if err != nil {
-		return nil, fmt.Errorf("read versions: %w", err)
-	}
-
-	if !found {
-		return clean, nil
-	}
-
-	rawVersions, _, err := unstructured.NestedSlice(raw, "spec", "versions")
-	if err != nil {
-		return nil, fmt.Errorf("read desired versions: %w", err)
-	}
-
-	for i, version := range cleanVersions {
-		versionMap, ok := version.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		name, _, _ := unstructured.NestedString(versionMap, "name")
-
-		rawSchema, ok := findVersionSchema(rawVersions, name)
-		if !ok {
-			continue
-		}
-
-		props := &openapi.JSONSchemaProps{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawSchema, props); err != nil {
-			return nil, fmt.Errorf("decode version %q schema: %w", name, err)
-		}
-
-		cleanSchema, err := runtime.DefaultUnstructuredConverter.ToUnstructured(props)
-		if err != nil {
-			return nil, fmt.Errorf("encode version %q schema: %w", name, err)
-		}
-
-		if err := unstructured.SetNestedMap(versionMap, cleanSchema, "schema", "openAPIV3Schema"); err != nil {
-			return nil, fmt.Errorf("set version %q schema: %w", name, err)
-		}
-
-		cleanVersions[i] = versionMap
-	}
-
-	if err := unstructured.SetNestedSlice(clean.Object, cleanVersions, "spec", "versions"); err != nil {
-		return nil, fmt.Errorf("set versions: %w", err)
-	}
-
-	return clean, nil
-}
-
-// findVersionSchema returns the openAPIV3Schema of the named version, matching by name
-// rather than by index so it does not depend on the two documents agreeing on order.
-func findVersionSchema(versions []any, name string) (map[string]any, bool) {
 	for _, version := range versions {
 		versionMap, ok := version.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		if versionName, _, _ := unstructured.NestedString(versionMap, "name"); versionName != name {
+		schema, ok := versionMap["schema"].(map[string]any)
+		if !ok {
 			continue
 		}
 
-		schemaMap, found, err := unstructured.NestedMap(versionMap, "schema", "openAPIV3Schema")
-		if err != nil || !found {
-			return nil, false
+		rawSchema, ok := schema["openAPIV3Schema"].(map[string]any)
+		if !ok {
+			continue
 		}
 
-		return schemaMap, true
+		cleanSchema, err := openapi.Prune(rawSchema)
+		if err != nil {
+			name, _, _ := unstructured.NestedString(versionMap, "name")
+
+			return fmt.Errorf("version %q schema: %w", name, err)
+		}
+
+		schema["openAPIV3Schema"] = cleanSchema
 	}
 
-	return nil, false
+	return nil
+}
+
+// nestedValue returns the value at the given path without copying it, or nil if the path
+// does not lead to one. Errors are the same as absence for every caller here.
+func nestedValue(obj map[string]any, fields ...string) any {
+	value, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil || !found {
+		return nil
+	}
+
+	return value
+}
+
+// applyServerDefaults writes the .spec fields the apiserver fills in itself into the
+// document, so a manifest that omits them does not differ from the stored object on
+// every single reconcile.
+func applyServerDefaults(crd *apiextensionsv1.CustomResourceDefinition, desired *unstructured.Unstructured) error {
+	apiextensionsv1.SetDefaults_CustomResourceDefinitionSpec(&crd.Spec)
+
+	// spec.conversion is defaulted too, but updateOrInsertCRD always takes the in-cluster
+	// one, which the apiserver has already defaulted
+	names := map[string]string{
+		"singular": crd.Spec.Names.Singular,
+		"listKind": crd.Spec.Names.ListKind,
+	}
+
+	for field, value := range names {
+		if value == "" {
+			continue
+		}
+
+		if err := unstructured.SetNestedField(desired.Object, value, "spec", "names", field); err != nil {
+			return fmt.Errorf("set spec.names.%s: %w", field, err)
+		}
+	}
+
+	return nil
 }
 
 func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, desired *unstructured.Unstructured) error {
@@ -429,12 +427,14 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 		}
 
 		// both sides are pruned to the same field set now — the desired spec by sanitize,
-		// the existing one by the apiserver — so this can actually return early
-		// ponytail: apiserver-defaulted .spec fields may differ from the manifest and cause
-		// reconcile churn; the update stays idempotent, tighten the diff here if it ever churns.
+		// the existing one by the apiserver — so this can actually return early.
+		// Annotations are only checked for containment because they are merged, not replaced.
+		// ponytail: apiserver-defaulted .spec fields beyond spec.names may differ from the
+		// manifest and cause reconcile churn; the update stays idempotent, default them in
+		// applyServerDefaults if it ever churns.
 		if cmp.Equal(existingSpec, desiredSpec) &&
 			cmp.Equal(existing.GetLabels(), desired.GetLabels()) &&
-			cmp.Equal(existing.GetAnnotations(), desired.GetAnnotations()) {
+			containsAll(existing.GetAnnotations(), desired.GetAnnotations()) {
 			return nil
 		}
 
@@ -444,7 +444,10 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 			return fmt.Errorf("set spec: %w", err)
 		}
 		existing.SetLabels(desired.GetLabels())
-		existing.SetAnnotations(desired.GetAnnotations())
+		// annotations written by other actors — Helm ownership, kubectl last-applied — are
+		// merged with, not replaced by, the manifest's: dropping meta.helm.sh/release-name
+		// breaks the next helm upgrade of the chart that installed the CRD
+		existing.SetAnnotations(mergeAnnotations(existing.GetAnnotations(), desired.GetAnnotations()))
 		existing.SetResourceVersion(resourceVersion)
 
 		_, err = cp.k8sClient.Resource(crdGVR).Update(ctx, existing, apimachineryv1.UpdateOptions{})
@@ -457,6 +460,12 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 }
 
 func mergeLabels(u *unstructured.Unstructured, extra map[string]string) {
+	if len(extra) == 0 {
+		// nothing to add: writing an empty map here would set metadata.labels: {}, which
+		// never compares equal to the absent labels the apiserver returns
+		return
+	}
+
 	labels := u.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string, len(extra))
@@ -467,6 +476,29 @@ func mergeLabels(u *unstructured.Unstructured, extra map[string]string) {
 	}
 
 	u.SetLabels(labels)
+}
+
+// containsAll reports whether super holds every key of sub with the same value.
+func containsAll(super, sub map[string]string) bool {
+	for k, v := range sub {
+		if super[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+func mergeAnnotations(existing, desired map[string]string) map[string]string {
+	if existing == nil {
+		return desired
+	}
+
+	for k, v := range desired {
+		existing[k] = v
+	}
+
+	return existing
 }
 
 func (cp *CRDsInstaller) GetCRDFromCluster(ctx context.Context, crdName string) (*apiextensionsv1.CustomResourceDefinition, error) {

--- a/pkg/crd-installer/installer.go
+++ b/pkg/crd-installer/installer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 	"sync"
@@ -174,7 +175,9 @@ func (cp *CRDsInstaller) processCRD(ctx context.Context, crdFilePath string) err
 				break
 			}
 
-			return err
+			// the documents read so far may already have failed: reporting only the read
+			// error would hide them
+			return errors.Join(errs, err)
 		}
 
 		data := cp.buffer[:n]
@@ -221,8 +224,13 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 		return fmt.Errorf("default %s: %w", crd.Name, err)
 	}
 
-	if err := sanitize(desired); err != nil {
-		return fmt.Errorf("sanitize %s: %w", crd.Name, err)
+	// a schema this build cannot decode must not keep the CRD out of the cluster: the
+	// document is queued as it came — what the installer did before it pruned anything —
+	// and the error is reported afterwards. The apiserver prunes the key it does not
+	// understand, while a missing CRD takes every custom resource of that kind with it.
+	sanitizeErr := sanitize(desired)
+	if sanitizeErr != nil {
+		sanitizeErr = fmt.Errorf("sanitize %s: %w", crd.Name, sanitizeErr)
 	}
 
 	cp.k8sTasks.Go(func() error {
@@ -263,7 +271,7 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 		return err
 	})
 
-	return nil
+	return sanitizeErr
 }
 
 // sanitize drops the schema keys the apiserver does not know from the CRD document.
@@ -328,8 +336,28 @@ func nestedValue(obj map[string]any, fields ...string) any {
 // applyServerDefaults writes the .spec fields the apiserver fills in itself into the
 // document, so a manifest that omits them does not differ from the stored object on
 // every single reconcile.
+//
+// ponytail: only the .spec fields known to churn are written here; if a CRD still updates
+// on every reconcile, diff the stored object against the manifest and add the field that
+// differs.
 func applyServerDefaults(crd *apiextensionsv1.CustomResourceDefinition, desired *unstructured.Unstructured) error {
 	apiextensionsv1.SetDefaults_CustomResourceDefinitionSpec(&crd.Spec)
+
+	// served and storage have no omitempty upstream, so the stored object always carries
+	// both on every version — a manifest that omits either would differ from it forever
+	versions, _ := nestedValue(desired.Object, "spec", "versions").([]any)
+	for _, version := range versions {
+		versionMap, ok := version.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		for _, field := range []string{"served", "storage"} {
+			if _, ok := versionMap[field]; !ok {
+				versionMap[field] = false
+			}
+		}
+	}
 
 	// spec.conversion is defaulted too, but updateOrInsertCRD always takes the in-cluster
 	// one, which the apiserver has already defaulted
@@ -353,10 +381,10 @@ func applyServerDefaults(crd *apiextensionsv1.CustomResourceDefinition, desired 
 
 func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, desired *unstructured.Unstructured) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		desired.SetLabels(overlay(desired.GetLabels(), cp.crdExtraLabels))
+
 		existing, err := cp.k8sClient.Resource(crdGVR).Get(ctx, crd.GetName(), apimachineryv1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			mergeLabels(desired, cp.crdExtraLabels)
-
 			_, err = cp.k8sClient.Resource(crdGVR).Create(ctx, desired, apimachineryv1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("create crd: %w", err)
@@ -414,8 +442,6 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 			}
 		}
 
-		mergeLabels(desired, cp.crdExtraLabels)
-
 		desiredSpec, _, err := unstructured.NestedMap(desired.Object, "spec")
 		if err != nil {
 			return fmt.Errorf("read desired spec: %w", err)
@@ -426,15 +452,27 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 			return fmt.Errorf("read existing spec: %w", err)
 		}
 
-		// both sides are pruned to the same field set now — the desired spec by sanitize,
-		// the existing one by the apiserver — so this can actually return early.
-		// Annotations are only checked for containment because they are merged, not replaced.
-		// ponytail: apiserver-defaulted .spec fields beyond spec.names may differ from the
-		// manifest and cause reconcile churn; the update stays idempotent, default them in
-		// applyServerDefaults if it ever churns.
+		// labels and annotations belong to whoever wrote them: dropping
+		// app.kubernetes.io/managed-by or meta.helm.sh/release-name breaks the next helm
+		// upgrade of the chart that installed the CRD, so both maps are overlaid, never
+		// replaced. The result is what the object must end up holding, which is also what
+		// makes the comparison below exact.
+		//
+		// ponytail: overlaying means a key the manifest stops declaring stays in the
+		// cluster — retracting one needs the field ownership the apiserver keeps for
+		// server-side apply; switch this whole update to Apply if that ever matters.
+		labels := overlay(existing.GetLabels(), desired.GetLabels())
+		annotations := overlay(existing.GetAnnotations(), desired.GetAnnotations())
+
+		// The specs are compared, not merged: the desired one is pruned by sanitize and the
+		// existing one by the apiserver, so a manifest applied over the state the apiserver
+		// derived from it is a no-op. A .spec key this cluster's apiserver does not know is
+		// the exception — it prunes the key while the desired document keeps it, so that CRD
+		// is updated on every reconcile. Deliberate: the key is sent so an apiserver that
+		// does know it gets it.
 		if cmp.Equal(existingSpec, desiredSpec) &&
-			cmp.Equal(existing.GetLabels(), desired.GetLabels()) &&
-			containsAll(existing.GetAnnotations(), desired.GetAnnotations()) {
+			cmp.Equal(existing.GetLabels(), labels) &&
+			cmp.Equal(existing.GetAnnotations(), annotations) {
 			return nil
 		}
 
@@ -443,11 +481,8 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 		if err := unstructured.SetNestedMap(existing.Object, desiredSpec, "spec"); err != nil {
 			return fmt.Errorf("set spec: %w", err)
 		}
-		existing.SetLabels(desired.GetLabels())
-		// annotations written by other actors — Helm ownership, kubectl last-applied — are
-		// merged with, not replaced by, the manifest's: dropping meta.helm.sh/release-name
-		// breaks the next helm upgrade of the chart that installed the CRD
-		existing.SetAnnotations(mergeAnnotations(existing.GetAnnotations(), desired.GetAnnotations()))
+		existing.SetLabels(labels)
+		existing.SetAnnotations(annotations)
 		existing.SetResourceVersion(resourceVersion)
 
 		_, err = cp.k8sClient.Resource(crdGVR).Update(ctx, existing, apimachineryv1.UpdateOptions{})
@@ -459,46 +494,22 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 	})
 }
 
-func mergeLabels(u *unstructured.Unstructured, extra map[string]string) {
-	if len(extra) == 0 {
-		// nothing to add: writing an empty map here would set metadata.labels: {}, which
-		// never compares equal to the absent labels the apiserver returns
-		return
+// overlay returns base with over's keys written on top of it. A key base holds and over
+// does not is kept.
+//
+// nil in, nil out: the apiserver returns no map at all for empty labels or annotations, and
+// an empty one written back would never compare equal to that — SetLabels/SetAnnotations
+// remove the field for nil and set metadata.labels: {} for an empty map.
+func overlay(base, over map[string]string) map[string]string {
+	if len(over) == 0 {
+		return base
 	}
 
-	labels := u.GetLabels()
-	if labels == nil {
-		labels = make(map[string]string, len(extra))
-	}
+	out := make(map[string]string, len(base)+len(over))
+	maps.Copy(out, base)
+	maps.Copy(out, over)
 
-	for k, v := range extra {
-		labels[k] = v
-	}
-
-	u.SetLabels(labels)
-}
-
-// containsAll reports whether super holds every key of sub with the same value.
-func containsAll(super, sub map[string]string) bool {
-	for k, v := range sub {
-		if super[k] != v {
-			return false
-		}
-	}
-
-	return true
-}
-
-func mergeAnnotations(existing, desired map[string]string) map[string]string {
-	if existing == nil {
-		return desired
-	}
-
-	for k, v := range desired {
-		existing[k] = v
-	}
-
-	return existing
+	return out
 }
 
 func (cp *CRDsInstaller) GetCRDFromCluster(ctx context.Context, crdName string) (*apiextensionsv1.CustomResourceDefinition, error) {

--- a/pkg/crd-installer/installer.go
+++ b/pkg/crd-installer/installer.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/deckhouse/module-sdk/pkg/crd-installer/openapi"
 	"github.com/deckhouse/module-sdk/pkg/utils"
 )
 
@@ -192,8 +193,8 @@ func (cp *CRDsInstaller) processCRD(ctx context.Context, crdFilePath string) err
 }
 
 func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reader, bufferSize int) error {
-	// Decode into unstructured so vendor schema extensions (x-kubernetes-*, x-ui-*, ...)
-	// survive verbatim; the typed struct below is used only to read metadata.
+	// Decode into unstructured first: the typed struct below cannot hold
+	// x-kubernetes-sensitive-data, and sanitize needs the original document to recover it.
 	desired := &unstructured.Unstructured{}
 	err := apimachineryYaml.NewYAMLOrJSONDecoder(crdReader, bufferSize).Decode(&desired)
 	if err != nil {
@@ -211,6 +212,11 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 	}
 	if crd.APIVersion != apiextensionsv1.SchemeGroupVersion.String() || crd.Kind != "CustomResourceDefinition" {
 		return fmt.Errorf("invalid CRD document apiversion/kind: '%s/%s'", crd.APIVersion, crd.Kind)
+	}
+
+	desired, err = sanitize(crd, desired.Object)
+	if err != nil {
+		return fmt.Errorf("sanitize %s: %w", crd.Name, err)
 	}
 
 	cp.k8sTasks.Go(func() error {
@@ -252,6 +258,99 @@ func (cp *CRDsInstaller) putCRDToCluster(ctx context.Context, crdReader io.Reade
 	})
 
 	return nil
+}
+
+// sanitize reduces the CRD document to the fields the apiserver actually knows.
+//
+// Everything else — x-doc-examples and friends, plus keys that look official but are
+// not, like x-kubernetes-immutable — is dropped here instead of being sent. The
+// apiserver prunes them anyway, after logging one "unknown field" warning per
+// occurrence, and because it prunes them the stored spec could never equal the desired
+// one, so every run issued a pointless Update.
+//
+// The typed CRD is that pruned document already, at every level. The single exception
+// is x-kubernetes-sensitive-data, which apiextensionsv1 does not model but the Deckhouse
+// apiserver does, so each version schema is re-decoded through the fork in
+// pkg/crd-installer/openapi that carries it.
+func sanitize(crd *apiextensionsv1.CustomResourceDefinition, raw map[string]any) (*unstructured.Unstructured, error) {
+	clean, err := utils.ToUnstructured(crd)
+	if err != nil {
+		return nil, fmt.Errorf("crd to unstructured: %w", err)
+	}
+
+	cleanVersions, found, err := unstructured.NestedSlice(clean.Object, "spec", "versions")
+	if err != nil {
+		return nil, fmt.Errorf("read versions: %w", err)
+	}
+
+	if !found {
+		return clean, nil
+	}
+
+	rawVersions, _, err := unstructured.NestedSlice(raw, "spec", "versions")
+	if err != nil {
+		return nil, fmt.Errorf("read desired versions: %w", err)
+	}
+
+	for i, version := range cleanVersions {
+		versionMap, ok := version.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _, _ := unstructured.NestedString(versionMap, "name")
+
+		rawSchema, ok := findVersionSchema(rawVersions, name)
+		if !ok {
+			continue
+		}
+
+		props := &openapi.JSONSchemaProps{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawSchema, props); err != nil {
+			return nil, fmt.Errorf("decode version %q schema: %w", name, err)
+		}
+
+		cleanSchema, err := runtime.DefaultUnstructuredConverter.ToUnstructured(props)
+		if err != nil {
+			return nil, fmt.Errorf("encode version %q schema: %w", name, err)
+		}
+
+		if err := unstructured.SetNestedMap(versionMap, cleanSchema, "schema", "openAPIV3Schema"); err != nil {
+			return nil, fmt.Errorf("set version %q schema: %w", name, err)
+		}
+
+		cleanVersions[i] = versionMap
+	}
+
+	if err := unstructured.SetNestedSlice(clean.Object, cleanVersions, "spec", "versions"); err != nil {
+		return nil, fmt.Errorf("set versions: %w", err)
+	}
+
+	return clean, nil
+}
+
+// findVersionSchema returns the openAPIV3Schema of the named version, matching by name
+// rather than by index so it does not depend on the two documents agreeing on order.
+func findVersionSchema(versions []any, name string) (map[string]any, bool) {
+	for _, version := range versions {
+		versionMap, ok := version.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if versionName, _, _ := unstructured.NestedString(versionMap, "name"); versionName != name {
+			continue
+		}
+
+		schemaMap, found, err := unstructured.NestedMap(versionMap, "schema", "openAPIV3Schema")
+		if err != nil || !found {
+			return nil, false
+		}
+
+		return schemaMap, true
+	}
+
+	return nil, false
 }
 
 func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, desired *unstructured.Unstructured) error {
@@ -329,7 +428,8 @@ func (cp *CRDsInstaller) updateOrInsertCRD(ctx context.Context, crd *apiextensio
 			return fmt.Errorf("read existing spec: %w", err)
 		}
 
-		// diff on lossless unstructured specs so vendor extensions are not silently dropped
+		// both sides are pruned to the same field set now — the desired spec by sanitize,
+		// the existing one by the apiserver — so this can actually return early
 		// ponytail: apiserver-defaulted .spec fields may differ from the manifest and cause
 		// reconcile churn; the update stays idempotent, tighten the diff here if it ever churns.
 		if cmp.Equal(existingSpec, desiredSpec) &&

--- a/pkg/crd-installer/installer_test.go
+++ b/pkg/crd-installer/installer_test.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -42,9 +41,7 @@ func countUpdates(actions []k8stesting.Action, name string) int {
 // exact Go values it is handed, so without this an object built with float64 numbers
 // reads back as float64 and a test can pass on state a real apiserver would never
 // return.
-func storeAsWire(t *testing.T, fc *fake.FakeDynamicClient) {
-	t.Helper()
-
+func storeAsWire(fc *fake.FakeDynamicClient) {
 	react := func(action k8stesting.Action) (bool, runtime.Object, error) {
 		withObject, ok := action.(interface{ GetObject() runtime.Object })
 		if !ok {
@@ -56,11 +53,18 @@ func storeAsWire(t *testing.T, fc *fake.FakeDynamicClient) {
 			return false, nil, nil
 		}
 
+		// the reactor runs on the installer's worker goroutines, so an error is returned to
+		// the caller rather than asserted: require.NoError would call t.FailNow off the test
+		// goroutine, which unwinds that worker and reports nothing about the CRD it dropped
 		data, err := json.Marshal(obj.Object)
-		require.NoError(t, err)
+		if err != nil {
+			return true, nil, err
+		}
 
 		wire := map[string]any{}
-		require.NoError(t, json.Unmarshal(data, &wire))
+		if err := json.Unmarshal(data, &wire); err != nil {
+			return true, nil, err
+		}
 
 		// ObjectMeta.Labels/Annotations are omitempty, so the apiserver never returns an
 		// empty map for them — it returns nothing
@@ -95,7 +99,7 @@ func TestCRDInstaller(t *testing.T) {
 	}
 
 	fc := fake.NewSimpleDynamicClient(crdScheme)
-	storeAsWire(t, fc)
+	storeAsWire(fc)
 
 	t.Run("install CRD", func(t *testing.T) {
 		inst := NewCRDsInstaller(fc, []string{"testdata/1_example.yaml"}, WithExtraLabels(map[string]string{"heritage": "deckhouse"}))
@@ -124,7 +128,9 @@ func TestCRDInstaller(t *testing.T) {
 		un, err := fc.Resource(gvr).Get(context.Background(), "widgets.example.com", apimachineryv1.GetOptions{})
 		require.NoError(t, err)
 
-		assert.Equal(t, map[string]string{"foo": "bar", "one": "new", "another": "lab"}, un.GetLabels())
+		// heritage is from the previous run: labels are overlaid, so a key this run no longer
+		// declares is left in place rather than deleted
+		assert.Equal(t, map[string]string{"foo": "bar", "one": "new", "another": "lab", "heritage": "deckhouse"}, un.GetLabels())
 		assert.Equal(t, map[string]string{"bar": "baz", "two": "new"}, un.GetAnnotations())
 		var crd v1.CustomResourceDefinition
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &crd)
@@ -293,44 +299,85 @@ func TestCRDInstaller(t *testing.T) {
 	})
 
 	// Regression: sanitize runs before the CRD is queued, so an error from it used to abort
-	// the whole file and silently skip every document after the bad one.
+	// the whole file and silently skip every document after the bad one. It must not keep the
+	// CRD it failed on out of the cluster either: the apiserver prunes the key it cannot
+	// read, while a missing CRD takes every custom resource of that kind with it.
 	t.Run("a bad document does not skip the rest of the file", func(t *testing.T) {
 		inst := NewCRDsInstaller(fc, []string{"testdata/10_multi_document.yaml"})
 		require.Error(t, inst.Run(context.Background()), "the broken document must still be reported")
 
-		for _, name := range []string{"firsts.example.com", "lasts.example.com"} {
+		for _, name := range []string{"firsts.example.com", "broken.example.com", "lasts.example.com"} {
 			_, err := fc.Resource(gvr).Get(context.Background(), name, apimachineryv1.GetOptions{})
-			require.NoError(t, err, "%s is a valid CRD in the same file and must be installed", name)
+			require.NoError(t, err, "%s is in the same file and must be installed", name)
 		}
-	})
 
-	// Regression: annotations belong to whoever wrote them. Replacing the map wholesale
-	// dropped the Helm ownership keys, and the next helm upgrade of that chart then failed
-	// on "invalid ownership metadata".
-	t.Run("keeps annotations written by other actors", func(t *testing.T) {
-		// widgets.example.com is already in the cluster from the subtests above; give it the
-		// ownership annotations a helm-installed CRD carries
-		_, err := fc.Resource(gvr).Patch(context.Background(), "widgets.example.com", types.MergePatchType,
-			[]byte(`{"metadata":{"annotations":{"meta.helm.sh/release-name":"some-chart"}}}`),
-			apimachineryv1.PatchOptions{})
+		un, err := fc.Resource(gvr).Get(context.Background(), "broken.example.com", apimachineryv1.GetOptions{})
 		require.NoError(t, err)
 
-		inst := NewCRDsInstaller(fc, []string{"testdata/2_example.yaml"})
-		require.NoError(t, inst.Run(context.Background()))
+		versions, _, err := unstructured.NestedSlice(un.Object, "spec", "versions")
+		require.NoError(t, err)
+
+		token, found, err := unstructured.NestedMap(versions[0].(map[string]any),
+			"schema", "openAPIV3Schema", "properties", "token")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		assert.Equal(t, "yes", token["x-kubernetes-sensitive-data"],
+			"a schema the fork cannot decode is sent as it came, for the apiserver to prune")
+	})
+
+	// Regression: labels and annotations belong to whoever wrote them. Replacing either map
+	// wholesale dropped the Helm ownership keys — app.kubernetes.io/managed-by among the
+	// labels, meta.helm.sh/* among the annotations — and the next helm upgrade of that chart
+	// then failed on "invalid ownership metadata".
+	t.Run("keeps labels and annotations written by other actors", func(t *testing.T) {
+		// own client: the CRD must be reached by the update path with nothing but the seeded
+		// state, otherwise a leftover from another subtest can be what forces the update
+		fc := fake.NewSimpleDynamicClient(crdScheme)
+		storeAsWire(fc)
+
+		// widgets.example.com as a helm chart installed it
+		seed := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name":        "widgets.example.com",
+				"labels":      map[string]any{"app.kubernetes.io/managed-by": "Helm"},
+				"annotations": map[string]any{"meta.helm.sh/release-name": "some-chart"},
+			},
+			"spec": map[string]any{
+				"group": "example.com",
+				"names": map[string]any{
+					"kind": "Widget", "listKind": "WidgetList", "plural": "widgets", "singular": "widget",
+				},
+				"scope":    "Namespaced",
+				"versions": []any{map[string]any{"name": "v1", "served": true, "storage": true}},
+			},
+		}}
+		_, err := fc.Resource(gvr).Create(context.Background(), seed, apimachineryv1.CreateOptions{})
+		require.NoError(t, err)
+
+		extra := WithExtraLabels(map[string]string{"heritage": "deckhouse"})
+		require.NoError(t, NewCRDsInstaller(fc, []string{"testdata/2_example.yaml"}, extra).Run(context.Background()))
 
 		un, err := fc.Resource(gvr).Get(context.Background(), "widgets.example.com", apimachineryv1.GetOptions{})
 		require.NoError(t, err)
 
 		assert.Equal(t, map[string]string{
-			"bar": "baz", "two": "new", "meta.helm.sh/release-name": "some-chart",
-		}, un.GetAnnotations())
+			"foo": "bar", "one": "new", "heritage": "deckhouse",
+			"app.kubernetes.io/managed-by": "Helm",
+		}, un.GetLabels(), "the helm ownership label must survive the update")
+		assert.Equal(t, map[string]string{
+			"bar": "baz", "two": "new",
+			"meta.helm.sh/release-name": "some-chart",
+		}, un.GetAnnotations(), "the helm ownership annotation must survive the update")
 
 		before := countUpdates(fc.Actions(), "widgets.example.com")
 
-		require.NoError(t, NewCRDsInstaller(fc, []string{"testdata/2_example.yaml"}).Run(context.Background()))
+		require.NoError(t, NewCRDsInstaller(fc, []string{"testdata/2_example.yaml"}, extra).Run(context.Background()))
 
 		assert.Equal(t, before, countUpdates(fc.Actions(), "widgets.example.com"),
-			"a foreign annotation must not read as a diff either")
+			"foreign labels and annotations must not read as a diff either")
 	})
 
 	// Regression: a comment-only yaml document decodes to a nil object and must be skipped,

--- a/pkg/crd-installer/installer_test.go
+++ b/pkg/crd-installer/installer_test.go
@@ -13,7 +13,26 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
+
+func countUpdates(actions []k8stesting.Action, name string) int {
+	var n int
+
+	for _, action := range actions {
+		update, ok := action.(k8stesting.UpdateAction)
+		if !ok {
+			continue
+		}
+
+		obj, ok := update.GetObject().(*unstructured.Unstructured)
+		if ok && obj.GetName() == name {
+			n++
+		}
+	}
+
+	return n
+}
 
 func TestCRDInstaller(t *testing.T) {
 	crdScheme := runtime.NewScheme()
@@ -146,6 +165,70 @@ func TestCRDInstaller(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, found, "manifest schema must be applied")
 		assert.Equal(t, true, token["x-kubernetes-sensitive-data"])
+	})
+
+	// Regression: keys the apiserver does not know must never be sent. It prunes them
+	// anyway, one "unknown field" warning per occurrence, and the pruning is what made
+	// the desired spec permanently differ from the stored one.
+	t.Run("strips unknown schema extensions", func(t *testing.T) {
+		inst := NewCRDsInstaller(fc, []string{"testdata/6_unknown_extensions.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		un, err := fc.Resource(gvr).Get(context.Background(), "extensions.example.com", apimachineryv1.GetOptions{})
+		require.NoError(t, err)
+
+		versions, _, err := unstructured.NestedSlice(un.Object, "spec", "versions")
+		require.NoError(t, err)
+
+		root, found, err := unstructured.NestedMap(versions[0].(map[string]any), "schema", "openAPIV3Schema")
+		require.NoError(t, err)
+		require.True(t, found)
+
+		assert.NotContains(t, root, "x-doc-examples")
+		assert.NotContains(t, root, "x-description")
+
+		props, _, err := unstructured.NestedMap(root, "properties", "spec", "properties")
+		require.NoError(t, err)
+
+		token := props["token"].(map[string]any)
+		assert.Equal(t, true, token["x-kubernetes-sensitive-data"], "the one extension that must survive")
+		assert.NotContains(t, token, "x-doc-examples")
+
+		tags := props["tags"].(map[string]any)
+		assert.Equal(t, "set", tags["x-kubernetes-list-type"])
+		assert.NotContains(t, tags["items"].(map[string]any), "x-doc-examples")
+		assert.Equal(t, int64(1), tags["items"].(map[string]any)["minLength"])
+
+		assert.NotContains(t, props["labels"].(map[string]any)["additionalProperties"].(map[string]any), "x-doc-examples")
+		assert.Equal(t, true, props["free"].(map[string]any)["x-kubernetes-preserve-unknown-fields"])
+
+		legacy := props["legacy"].(map[string]any)
+		assert.Equal(t, "string", legacy["type"])
+		for _, key := range []string{
+			"x-kubernetes-immutable", "x-kubernetes-patch-strategy", "x-examples", "x-doc-default",
+		} {
+			assert.NotContains(t, legacy, key, "not a field of JSONSchemaProps")
+		}
+	})
+
+	// Regression: applying a manifest over the state the apiserver derives from it must be
+	// a no-op. The apiserver prunes the x-doc-* keys, so before the fix the desired spec
+	// (with them) could never equal the stored spec (without them) and every single run
+	// issued a full Update of every CRD.
+	//
+	// The fake client prunes nothing, so the pruned state has to be installed explicitly —
+	// reinstalling the same file twice would pass either way and prove nothing.
+	t.Run("applying a manifest over its stored form does not update", func(t *testing.T) {
+		inst := NewCRDsInstaller(fc, []string{"testdata/7_churn_stored.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		before := countUpdates(fc.Actions(), "churns.example.com")
+
+		inst = NewCRDsInstaller(fc, []string{"testdata/8_churn_manifest.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		assert.Equal(t, before, countUpdates(fc.Actions(), "churns.example.com"),
+			"the x-doc-* keys must not make the installer see a diff")
 	})
 
 	// Regression: a comment-only yaml document decodes to a nil object and must be skipped,

--- a/pkg/crd-installer/installer_test.go
+++ b/pkg/crd-installer/installer_test.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -20,18 +22,62 @@ func countUpdates(actions []k8stesting.Action, name string) int {
 	var n int
 
 	for _, action := range actions {
-		update, ok := action.(k8stesting.UpdateAction)
-		if !ok {
+		// k8stesting.CreateAction and UpdateAction are the same interface, so a create
+		// satisfies both: the verb is the only way to tell them apart. The subresource check
+		// keeps the storedVersions status write out of the count.
+		if action.GetVerb() != "update" || action.GetSubresource() != "" {
 			continue
 		}
 
-		obj, ok := update.GetObject().(*unstructured.Unstructured)
+		obj, ok := action.(k8stesting.UpdateAction).GetObject().(*unstructured.Unstructured)
 		if ok && obj.GetName() == name {
 			n++
 		}
 	}
 
 	return n
+}
+
+// storeAsWire makes the fake client behave the way the wire does. The tracker keeps the
+// exact Go values it is handed, so without this an object built with float64 numbers
+// reads back as float64 and a test can pass on state a real apiserver would never
+// return.
+func storeAsWire(t *testing.T, fc *fake.FakeDynamicClient) {
+	t.Helper()
+
+	react := func(action k8stesting.Action) (bool, runtime.Object, error) {
+		withObject, ok := action.(interface{ GetObject() runtime.Object })
+		if !ok {
+			return false, nil, nil
+		}
+
+		obj, ok := withObject.GetObject().(*unstructured.Unstructured)
+		if !ok {
+			return false, nil, nil
+		}
+
+		data, err := json.Marshal(obj.Object)
+		require.NoError(t, err)
+
+		wire := map[string]any{}
+		require.NoError(t, json.Unmarshal(data, &wire))
+
+		// ObjectMeta.Labels/Annotations are omitempty, so the apiserver never returns an
+		// empty map for them — it returns nothing
+		for _, field := range []string{"labels", "annotations"} {
+			if m, ok := nestedValue(wire, "metadata", field).(map[string]any); ok && len(m) == 0 {
+				unstructured.RemoveNestedField(wire, "metadata", field)
+			}
+		}
+
+		obj.Object = wire
+
+		// fall through to the object tracker, which stores a deep copy of what we just fixed
+		return false, nil, nil
+	}
+
+	fc.PrependReactor("create", "*", react)
+	fc.PrependReactor("update", "*", react)
 }
 
 func TestCRDInstaller(t *testing.T) {
@@ -49,6 +95,7 @@ func TestCRDInstaller(t *testing.T) {
 	}
 
 	fc := fake.NewSimpleDynamicClient(crdScheme)
+	storeAsWire(t, fc)
 
 	t.Run("install CRD", func(t *testing.T) {
 		inst := NewCRDsInstaller(fc, []string{"testdata/1_example.yaml"}, WithExtraLabels(map[string]string{"heritage": "deckhouse"}))
@@ -170,6 +217,10 @@ func TestCRDInstaller(t *testing.T) {
 	// Regression: keys the apiserver does not know must never be sent. It prunes them
 	// anyway, one "unknown field" warning per occurrence, and the pruning is what made
 	// the desired spec permanently differ from the stored one.
+	//
+	// This only checks that sanitize is reached from Run and applies to the whole schema
+	// tree; which keys survive at which nesting position is openapi.Prune's own job and is
+	// covered by TestRoundTrip* in that package.
 	t.Run("strips unknown schema extensions", func(t *testing.T) {
 		inst := NewCRDsInstaller(fc, []string{"testdata/6_unknown_extensions.yaml"})
 		require.NoError(t, inst.Run(context.Background()))
@@ -185,50 +236,101 @@ func TestCRDInstaller(t *testing.T) {
 		require.True(t, found)
 
 		assert.NotContains(t, root, "x-doc-examples")
-		assert.NotContains(t, root, "x-description")
 
-		props, _, err := unstructured.NestedMap(root, "properties", "spec", "properties")
+		token, found, err := unstructured.NestedMap(root, "properties", "spec", "properties", "token")
 		require.NoError(t, err)
+		require.True(t, found)
 
-		token := props["token"].(map[string]any)
 		assert.Equal(t, true, token["x-kubernetes-sensitive-data"], "the one extension that must survive")
 		assert.NotContains(t, token, "x-doc-examples")
+	})
 
-		tags := props["tags"].(map[string]any)
-		assert.Equal(t, "set", tags["x-kubernetes-list-type"])
-		assert.NotContains(t, tags["items"].(map[string]any), "x-doc-examples")
-		assert.Equal(t, int64(1), tags["items"].(map[string]any)["minLength"])
+	// Regression: a CRD field this build's apiextensions-apiserver does not model must
+	// still reach an apiserver that understands it — sanitize prunes schemas, not the
+	// document.
+	t.Run("keeps CRD fields outside the schema", func(t *testing.T) {
+		inst := NewCRDsInstaller(fc, []string{"testdata/9_unknown_crd_field.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
 
-		assert.NotContains(t, props["labels"].(map[string]any)["additionalProperties"].(map[string]any), "x-doc-examples")
-		assert.Equal(t, true, props["free"].(map[string]any)["x-kubernetes-preserve-unknown-fields"])
+		un, err := fc.Resource(gvr).Get(context.Background(), "futures.example.com", apimachineryv1.GetOptions{})
+		require.NoError(t, err)
 
-		legacy := props["legacy"].(map[string]any)
-		assert.Equal(t, "string", legacy["type"])
-		for _, key := range []string{
-			"x-kubernetes-immutable", "x-kubernetes-patch-strategy", "x-examples", "x-doc-default",
-		} {
-			assert.NotContains(t, legacy, key, "not a field of JSONSchemaProps")
-		}
+		versions, _, err := unstructured.NestedSlice(un.Object, "spec", "versions")
+		require.NoError(t, err)
+
+		assert.Equal(t, "a field from a newer apiserver", versions[0].(map[string]any)["fieldFromTheFuture"])
+		assert.NotContains(t, un.Object, "status", "the manifest declares no status, so none must be sent")
+
+		// the manifest has no labels and the installer adds none, so the second run must see
+		// the nil the cluster returns as equal to what it would write
+		before := countUpdates(fc.Actions(), "futures.example.com")
+
+		require.NoError(t, NewCRDsInstaller(fc, []string{"testdata/9_unknown_crd_field.yaml"}).Run(context.Background()))
+
+		assert.Equal(t, before, countUpdates(fc.Actions(), "futures.example.com"),
+			"a CRD without labels must not churn")
 	})
 
 	// Regression: applying a manifest over the state the apiserver derives from it must be
-	// a no-op. The apiserver prunes the x-doc-* keys, so before the fix the desired spec
-	// (with them) could never equal the stored spec (without them) and every single run
-	// issued a full Update of every CRD.
+	// a no-op. The apiserver prunes the x-doc-* keys, defaults spec.names and returns whole
+	// numbers as int64, so before the fix the desired spec could never equal the stored one
+	// and every single run issued a full Update of every CRD.
 	//
-	// The fake client prunes nothing, so the pruned state has to be installed explicitly —
-	// reinstalling the same file twice would pass either way and prove nothing.
+	// The fake client prunes and defaults nothing, so the derived state has to be installed
+	// explicitly — reinstalling the same file twice would pass either way and prove nothing.
 	t.Run("applying a manifest over its stored form does not update", func(t *testing.T) {
 		inst := NewCRDsInstaller(fc, []string{"testdata/7_churn_stored.yaml"})
 		require.NoError(t, inst.Run(context.Background()))
 
-		before := countUpdates(fc.Actions(), "churns.example.com")
+		require.Zero(t, countUpdates(fc.Actions(), "churns.example.com"),
+			"a CRD that is not in the cluster is created, not updated")
 
 		inst = NewCRDsInstaller(fc, []string{"testdata/8_churn_manifest.yaml"})
 		require.NoError(t, inst.Run(context.Background()))
 
-		assert.Equal(t, before, countUpdates(fc.Actions(), "churns.example.com"),
-			"the x-doc-* keys must not make the installer see a diff")
+		assert.Zero(t, countUpdates(fc.Actions(), "churns.example.com"),
+			"the doc keys, the defaulted names and the numeric bounds must not read as a diff")
+	})
+
+	// Regression: sanitize runs before the CRD is queued, so an error from it used to abort
+	// the whole file and silently skip every document after the bad one.
+	t.Run("a bad document does not skip the rest of the file", func(t *testing.T) {
+		inst := NewCRDsInstaller(fc, []string{"testdata/10_multi_document.yaml"})
+		require.Error(t, inst.Run(context.Background()), "the broken document must still be reported")
+
+		for _, name := range []string{"firsts.example.com", "lasts.example.com"} {
+			_, err := fc.Resource(gvr).Get(context.Background(), name, apimachineryv1.GetOptions{})
+			require.NoError(t, err, "%s is a valid CRD in the same file and must be installed", name)
+		}
+	})
+
+	// Regression: annotations belong to whoever wrote them. Replacing the map wholesale
+	// dropped the Helm ownership keys, and the next helm upgrade of that chart then failed
+	// on "invalid ownership metadata".
+	t.Run("keeps annotations written by other actors", func(t *testing.T) {
+		// widgets.example.com is already in the cluster from the subtests above; give it the
+		// ownership annotations a helm-installed CRD carries
+		_, err := fc.Resource(gvr).Patch(context.Background(), "widgets.example.com", types.MergePatchType,
+			[]byte(`{"metadata":{"annotations":{"meta.helm.sh/release-name":"some-chart"}}}`),
+			apimachineryv1.PatchOptions{})
+		require.NoError(t, err)
+
+		inst := NewCRDsInstaller(fc, []string{"testdata/2_example.yaml"})
+		require.NoError(t, inst.Run(context.Background()))
+
+		un, err := fc.Resource(gvr).Get(context.Background(), "widgets.example.com", apimachineryv1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]string{
+			"bar": "baz", "two": "new", "meta.helm.sh/release-name": "some-chart",
+		}, un.GetAnnotations())
+
+		before := countUpdates(fc.Actions(), "widgets.example.com")
+
+		require.NoError(t, NewCRDsInstaller(fc, []string{"testdata/2_example.yaml"}).Run(context.Background()))
+
+		assert.Equal(t, before, countUpdates(fc.Actions(), "widgets.example.com"),
+			"a foreign annotation must not read as a diff either")
 	})
 
 	// Regression: a comment-only yaml document decodes to a nil object and must be skipped,

--- a/pkg/crd-installer/openapi/marshal.go
+++ b/pkg/crd-installer/openapi/marshal.go
@@ -1,0 +1,130 @@
+package openapi
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+// Ported from k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/marshal.go.
+// The CBOR halves are left out: these types are only ever an intermediate step
+// between two map[string]interface{} values and never cross the wire themselves.
+
+var (
+	jsTrue  = []byte("true")
+	jsFalse = []byte("false")
+)
+
+func (s JSONSchemaPropsOrBool) MarshalJSON() ([]byte, error) {
+	if s.Schema != nil {
+		return json.Marshal(s.Schema)
+	}
+
+	if s.Schema == nil && !s.Allows {
+		return jsFalse, nil
+	}
+
+	return jsTrue, nil
+}
+
+func (s *JSONSchemaPropsOrBool) UnmarshalJSON(data []byte) error {
+	var nw JSONSchemaPropsOrBool
+
+	switch {
+	case len(data) == 0:
+	case data[0] == '{':
+		var sch JSONSchemaProps
+		if err := json.Unmarshal(data, &sch); err != nil {
+			return err
+		}
+
+		nw.Allows = true
+		nw.Schema = &sch
+	case len(data) == 4 && string(data) == "true":
+		nw.Allows = true
+	case len(data) == 5 && string(data) == "false":
+		nw.Allows = false
+	default:
+		return errors.New("boolean or JSON schema expected")
+	}
+
+	*s = nw
+
+	return nil
+}
+
+func (s JSONSchemaPropsOrStringArray) MarshalJSON() ([]byte, error) {
+	if len(s.Property) > 0 {
+		return json.Marshal(s.Property)
+	}
+
+	if s.Schema != nil {
+		return json.Marshal(s.Schema)
+	}
+
+	return []byte("null"), nil
+}
+
+func (s *JSONSchemaPropsOrStringArray) UnmarshalJSON(data []byte) error {
+	var first byte
+	if len(data) > 1 {
+		first = data[0]
+	}
+
+	var nw JSONSchemaPropsOrStringArray
+
+	if first == '{' {
+		var sch JSONSchemaProps
+		if err := json.Unmarshal(data, &sch); err != nil {
+			return err
+		}
+
+		nw.Schema = &sch
+	}
+
+	if first == '[' {
+		if err := json.Unmarshal(data, &nw.Property); err != nil {
+			return err
+		}
+	}
+
+	*s = nw
+
+	return nil
+}
+
+func (s JSONSchemaPropsOrArray) MarshalJSON() ([]byte, error) {
+	if len(s.JSONSchemas) > 0 {
+		return json.Marshal(s.JSONSchemas)
+	}
+
+	return json.Marshal(s.Schema)
+}
+
+func (s *JSONSchemaPropsOrArray) UnmarshalJSON(data []byte) error {
+	var nw JSONSchemaPropsOrArray
+
+	var first byte
+	if len(data) > 1 {
+		first = data[0]
+	}
+
+	if first == '{' {
+		var sch JSONSchemaProps
+		if err := json.Unmarshal(data, &sch); err != nil {
+			return err
+		}
+
+		nw.Schema = &sch
+	}
+
+	if first == '[' {
+		if err := json.Unmarshal(data, &nw.JSONSchemas); err != nil {
+			return err
+		}
+	}
+
+	*s = nw
+
+	return nil
+}

--- a/pkg/crd-installer/openapi/marshal_test.go
+++ b/pkg/crd-installer/openapi/marshal_test.go
@@ -1,0 +1,58 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+// TestForkMarshalsLikeUpstream is the guard the reflection tests in types_test.go cannot
+// be. Every field of the union types is json:"-", so the bytes they produce are decided by
+// the hand-ported marshallers in marshal.go alone: a drift there — null instead of [], a
+// lost Allows — changes what the installer applies to every CRD using that keyword while
+// both field-set comparisons still pass. Only the bytes show it.
+func TestForkMarshalsLikeUpstream(t *testing.T) {
+	// x-kubernetes-sensitive-data is left out on purpose: the upstream type cannot hold it,
+	// and TestRoundTripKeepsKnownFields already covers it
+	raw := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			// items, single-schema form
+			"tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			// items, tuple form
+			"pair": map[string]any{"type": "array", "items": []any{
+				map[string]any{"type": "string"},
+				map[string]any{"type": "integer"},
+			}},
+			// additionalProperties in all three forms
+			"labels": map[string]any{"type": "object", "additionalProperties": map[string]any{"type": "string"}},
+			"free":   map[string]any{"type": "object", "additionalProperties": true},
+			"closed": map[string]any{"type": "object", "additionalProperties": false},
+			"list":   map[string]any{"type": "array", "additionalItems": true},
+			// dependencies in both forms
+			"deps": map[string]any{"type": "object", "dependencies": map[string]any{
+				"needsOther": []any{"other"},
+				"needsShape": map[string]any{"type": "string"},
+			}},
+		},
+	}
+
+	fork := &JSONSchemaProps{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(raw, fork))
+
+	upstream := &apiextensionsv1.JSONSchemaProps{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(raw, upstream))
+
+	forkJSON, err := json.Marshal(fork)
+	require.NoError(t, err)
+
+	upstreamJSON, err := json.Marshal(upstream)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(upstreamJSON), string(forkJSON),
+		"port the upstream marshal.go change into this package's")
+}

--- a/pkg/crd-installer/openapi/marshal_test.go
+++ b/pkg/crd-installer/openapi/marshal_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -41,11 +40,15 @@ func TestForkMarshalsLikeUpstream(t *testing.T) {
 		},
 	}
 
+	// decoded the way Prune does it, so the marshallers are fed what they see in production
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
+
 	fork := &JSONSchemaProps{}
-	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(raw, fork))
+	require.NoError(t, json.Unmarshal(data, fork))
 
 	upstream := &apiextensionsv1.JSONSchemaProps{}
-	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(raw, upstream))
+	require.NoError(t, json.Unmarshal(data, upstream))
 
 	forkJSON, err := json.Marshal(fork)
 	require.NoError(t, err)

--- a/pkg/crd-installer/openapi/prune.go
+++ b/pkg/crd-installer/openapi/prune.go
@@ -1,0 +1,35 @@
+package openapi
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+// Prune returns the schema with every key that is not a field of JSONSchemaProps
+// removed, at every nesting level.
+//
+// The result is encoded through JSON rather than through the reflection converter so
+// that whole numbers come back as int64, exactly as they arrive from the apiserver.
+// Reflection encodes maximum/minimum/multipleOf as float64 — the Go type of those
+// fields — and a desired spec carrying float64 could never compare equal to the stored
+// one, so every reconcile would issue an Update.
+func Prune(raw map[string]any) (map[string]any, error) {
+	props := &JSONSchemaProps{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw, props); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+
+	data, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("encode: %w", err)
+	}
+
+	clean := map[string]any{}
+	if err := json.Unmarshal(data, &clean); err != nil {
+		return nil, fmt.Errorf("decode pruned: %w", err)
+	}
+
+	return clean, nil
+}

--- a/pkg/crd-installer/openapi/prune.go
+++ b/pkg/crd-installer/openapi/prune.go
@@ -3,27 +3,38 @@ package openapi
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
 // Prune returns the schema with every key that is not a field of JSONSchemaProps
 // removed, at every nesting level.
 //
-// The result is encoded through JSON rather than through the reflection converter so
-// that whole numbers come back as int64, exactly as they arrive from the apiserver.
-// Reflection encodes maximum/minimum/multipleOf as float64 — the Go type of those
-// fields — and a desired spec carrying float64 could never compare equal to the stored
-// one, so every reconcile would issue an Update.
+// Everything goes through json rather than through the reflection converter, in both
+// directions. Reflection is not an option here: it inlines an embedded field into the
+// same map instead of applying json's depth rule, so it would decode every nested
+// schema twice — once into JSONSchemaProps, once into the shadowed upstream field it
+// then throws away — and with KUBE_PATCH_CONVERSION_DETECTOR set apimachinery compares
+// the two decoders and klog.Fatalf's on the difference.
+//
+// The result comes back with whole numbers as int64, exactly as they arrive from the
+// apiserver. Reflection encodes maximum/minimum/multipleOf as float64 — the Go type of
+// those fields — and a desired spec carrying float64 could never compare equal to the
+// stored one, so every reconcile would issue an Update.
 func Prune(raw map[string]any) (map[string]any, error) {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("encode: %w", err)
+	}
+
+	// decoding into the type drops every key that is not one of its fields
 	props := &JSONSchemaProps{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(raw, props); err != nil {
+	if err := json.Unmarshal(data, props); err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 
-	data, err := json.Marshal(props)
+	data, err = json.Marshal(props)
 	if err != nil {
-		return nil, fmt.Errorf("encode: %w", err)
+		return nil, fmt.Errorf("encode pruned: %w", err)
 	}
 
 	clean := map[string]any{}

--- a/pkg/crd-installer/openapi/types.go
+++ b/pkg/crd-installer/openapi/types.go
@@ -1,0 +1,112 @@
+// Package openapi holds the CRD validation schema type that the installer applies
+// to the cluster.
+//
+// It is a fork of apiextensionsv1.JSONSchemaProps. The fork exists for exactly one
+// reason: the Deckhouse kube-apiserver carries 010-x-kubernetes-sensitive-data.patch
+// and runs with CRDSensitiveData=true, so it understands one schema field that the
+// stock apiextensions-apiserver Go types do not. Decoding a CRD through the upstream
+// type would drop that field before it ever reached the cluster.
+//
+// The fork is also the strict contract in the other direction: any key that is not a
+// field here — x-doc-examples, x-examples, x-description, x-kubernetes-immutable and
+// friends — is dropped on decode instead of being sent to the apiserver, which would
+// prune it anyway and log an "unknown field" warning for every occurrence.
+//
+// TestForkCoversUpstreamFields guards the copy against drift; read it before bumping
+// k8s.io/apiextensions-apiserver.
+package openapi
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+//
+// Field-for-field mirror of apiextensionsv1.JSONSchemaProps, with the nested schema
+// positions retargeted at this package and XSensitiveData added.
+type JSONSchemaProps struct {
+	ID          string                        `json:"id,omitempty"`
+	Schema      apiextensionsv1.JSONSchemaURL `json:"$schema,omitempty"`
+	Ref         *string                       `json:"$ref,omitempty"`
+	Description string                        `json:"description,omitempty"`
+	Type        string                        `json:"type,omitempty"`
+	Format      string                        `json:"format,omitempty"`
+
+	Title            string                `json:"title,omitempty"`
+	Default          *apiextensionsv1.JSON `json:"default,omitempty"`
+	Maximum          *float64              `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                  `json:"exclusiveMaximum,omitempty"`
+	Minimum          *float64              `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                  `json:"exclusiveMinimum,omitempty"`
+	MaxLength        *int64                `json:"maxLength,omitempty"`
+	MinLength        *int64                `json:"minLength,omitempty"`
+	Pattern          string                `json:"pattern,omitempty"`
+	MaxItems         *int64                `json:"maxItems,omitempty"`
+	MinItems         *int64                `json:"minItems,omitempty"`
+	UniqueItems      bool                  `json:"uniqueItems,omitempty"`
+	MultipleOf       *float64              `json:"multipleOf,omitempty"`
+
+	Enum          []apiextensionsv1.JSON `json:"enum,omitempty"`
+	MaxProperties *int64                 `json:"maxProperties,omitempty"`
+	MinProperties *int64                 `json:"minProperties,omitempty"`
+
+	Required []string                `json:"required,omitempty"`
+	Items    *JSONSchemaPropsOrArray `json:"items,omitempty"`
+
+	AllOf                []JSONSchemaProps                      `json:"allOf,omitempty"`
+	OneOf                []JSONSchemaProps                      `json:"oneOf,omitempty"`
+	AnyOf                []JSONSchemaProps                      `json:"anyOf,omitempty"`
+	Not                  *JSONSchemaProps                       `json:"not,omitempty"`
+	Properties           map[string]JSONSchemaProps             `json:"properties,omitempty"`
+	AdditionalProperties *JSONSchemaPropsOrBool                 `json:"additionalProperties,omitempty"`
+	PatternProperties    map[string]JSONSchemaProps             `json:"patternProperties,omitempty"`
+	Dependencies         JSONSchemaDependencies                 `json:"dependencies,omitempty"`
+	AdditionalItems      *JSONSchemaPropsOrBool                 `json:"additionalItems,omitempty"`
+	Definitions          JSONSchemaDefinitions                  `json:"definitions,omitempty"`
+	ExternalDocs         *apiextensionsv1.ExternalDocumentation `json:"externalDocs,omitempty"`
+	Example              *apiextensionsv1.JSON                  `json:"example,omitempty"`
+	Nullable             bool                                   `json:"nullable,omitempty"`
+
+	XPreserveUnknownFields *bool                           `json:"x-kubernetes-preserve-unknown-fields,omitempty"`
+	XEmbeddedResource      bool                            `json:"x-kubernetes-embedded-resource,omitempty"`
+	XIntOrString           bool                            `json:"x-kubernetes-int-or-string,omitempty"`
+	XListMapKeys           []string                        `json:"x-kubernetes-list-map-keys,omitempty"`
+	XListType              *string                         `json:"x-kubernetes-list-type,omitempty"`
+	XMapType               *string                         `json:"x-kubernetes-map-type,omitempty"`
+	XValidations           apiextensionsv1.ValidationRules `json:"x-kubernetes-validations,omitempty"`
+
+	// XSensitiveData marks a field (or an object/array subtree) as sensitive: the
+	// apiserver encrypts it in etcd, filters it by RBAC through the <resource>/sensitive
+	// subresource, and masks it in audit logs.
+	//
+	// This is NOT an upstream Kubernetes field. It only exists on the Deckhouse
+	// kube-apiserver, and it is the sole reason this package forks JSONSchemaProps.
+	// Keep it listed in forkOnlyFields in the test when adding others.
+	XSensitiveData bool `json:"x-kubernetes-sensitive-data,omitempty"`
+}
+
+// JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps
+// or an array of JSONSchemaProps. Mainly here for serialization purposes.
+type JSONSchemaPropsOrArray struct {
+	Schema      *JSONSchemaProps  `json:"-"`
+	JSONSchemas []JSONSchemaProps `json:"-"`
+}
+
+// JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value.
+// Defaults to true for the boolean property.
+type JSONSchemaPropsOrBool struct {
+	Allows bool             `json:"-"`
+	Schema *JSONSchemaProps `json:"-"`
+}
+
+// JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array.
+type JSONSchemaPropsOrStringArray struct {
+	Schema   *JSONSchemaProps `json:"-"`
+	Property []string         `json:"-"`
+}
+
+// JSONSchemaDependencies represent a dependencies property.
+type JSONSchemaDependencies map[string]JSONSchemaPropsOrStringArray
+
+// JSONSchemaDefinitions contains the models explicitly defined in this spec.
+type JSONSchemaDefinitions map[string]JSONSchemaProps

--- a/pkg/crd-installer/openapi/types.go
+++ b/pkg/crd-installer/openapi/types.go
@@ -12,6 +12,12 @@
 // friends — is dropped on decode instead of being sent to the apiserver, which would
 // prune it anyway and log an "unknown field" warning for every occurrence.
 //
+// The contract holds only on the Deckhouse kube-apiserver. On a stock one — a managed
+// control plane, a dev cluster, CRDSensitiveData off — x-kubernetes-sensitive-data is
+// pruned server-side, so a CRD that carries it is updated on every reconcile. That is
+// accepted: the field is meaningless there anyway, and detecting it would mean probing
+// the apiserver build for every install.
+//
 // TestForkCoversUpstreamFields guards the copy against drift; read it before bumping
 // k8s.io/apiextensions-apiserver.
 package openapi

--- a/pkg/crd-installer/openapi/types.go
+++ b/pkg/crd-installer/openapi/types.go
@@ -1,13 +1,17 @@
 // Package openapi holds the CRD validation schema type that the installer applies
 // to the cluster.
 //
-// It is a fork of apiextensionsv1.JSONSchemaProps. The fork exists for exactly one
-// reason: the Deckhouse kube-apiserver carries 010-x-kubernetes-sensitive-data.patch
-// and runs with CRDSensitiveData=true, so it understands one schema field that the
-// stock apiextensions-apiserver Go types do not. Decoding a CRD through the upstream
-// type would drop that field before it ever reached the cluster.
+// JSONSchemaProps embeds apiextensionsv1.JSONSchemaProps and adds the one field the
+// stock type cannot hold: the Deckhouse kube-apiserver carries
+// 010-x-kubernetes-sensitive-data.patch and runs with CRDSensitiveData=true, so it
+// understands x-kubernetes-sensitive-data. Decoding a CRD through the upstream type
+// alone would drop that field before it ever reached the cluster.
 //
-// The fork is also the strict contract in the other direction: any key that is not a
+// Only the positions that carry a nested schema are redeclared here, so the extension
+// survives at any depth. Every other schema field — its type, its json tag, its
+// omitempty — is inherited from upstream and cannot drift.
+//
+// The type is also the strict contract in the other direction: any key that is not a
 // field here — x-doc-examples, x-examples, x-description, x-kubernetes-immutable and
 // friends — is dropped on decode instead of being sent to the apiserver, which would
 // prune it anyway and log an "unknown field" warning for every occurrence.
@@ -22,10 +26,10 @@
 // understands and this build does not is dropped silently, and TestForkCoversUpstreamFields
 // only fires when this module bumps k8s.io/apiextensions-apiserver — never when the cluster
 // moves ahead of it. Keep the dependency in step with the apiserver Deckhouse ships. A
-// schema this fork cannot decode at all is not dropped: the installer sends that document
-// as it came and reports the error (see sanitize).
+// schema this package cannot decode at all is not dropped: the installer sends that
+// document as it came and reports the error (see sanitize).
 //
-// TestForkCoversUpstreamFields and TestForkMarshalsLikeUpstream guard the copy against
+// TestForkCoversUpstreamFields and TestForkMarshalsLikeUpstream guard the type against
 // drift; read them before bumping k8s.io/apiextensions-apiserver.
 package openapi
 
@@ -35,65 +39,37 @@ import (
 
 // JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
 //
-// Field-for-field mirror of apiextensionsv1.JSONSchemaProps, with the nested schema
-// positions retargeted at this package and XSensitiveData added.
+// It is apiextensionsv1.JSONSchemaProps with the nested schema positions retargeted at
+// this type and XSensitiveData added.
 type JSONSchemaProps struct {
-	ID          string                        `json:"id,omitempty"`
-	Schema      apiextensionsv1.JSONSchemaURL `json:"$schema,omitempty"`
-	Ref         *string                       `json:"$ref,omitempty"`
-	Description string                        `json:"description,omitempty"`
-	Type        string                        `json:"type,omitempty"`
-	Format      string                        `json:"format,omitempty"`
+	// every field that holds no nested schema, verbatim from upstream
+	apiextensionsv1.JSONSchemaProps `json:",inline"`
 
-	Title            string                `json:"title,omitempty"`
-	Default          *apiextensionsv1.JSON `json:"default,omitempty"`
-	Maximum          *float64              `json:"maximum,omitempty"`
-	ExclusiveMaximum bool                  `json:"exclusiveMaximum,omitempty"`
-	Minimum          *float64              `json:"minimum,omitempty"`
-	ExclusiveMinimum bool                  `json:"exclusiveMinimum,omitempty"`
-	MaxLength        *int64                `json:"maxLength,omitempty"`
-	MinLength        *int64                `json:"minLength,omitempty"`
-	Pattern          string                `json:"pattern,omitempty"`
-	MaxItems         *int64                `json:"maxItems,omitempty"`
-	MinItems         *int64                `json:"minItems,omitempty"`
-	UniqueItems      bool                  `json:"uniqueItems,omitempty"`
-	MultipleOf       *float64              `json:"multipleOf,omitempty"`
-
-	Enum          []apiextensionsv1.JSON `json:"enum,omitempty"`
-	MaxProperties *int64                 `json:"maxProperties,omitempty"`
-	MinProperties *int64                 `json:"minProperties,omitempty"`
-
-	Required []string                `json:"required,omitempty"`
-	Items    *JSONSchemaPropsOrArray `json:"items,omitempty"`
-
-	AllOf                []JSONSchemaProps                      `json:"allOf,omitempty"`
-	OneOf                []JSONSchemaProps                      `json:"oneOf,omitempty"`
-	AnyOf                []JSONSchemaProps                      `json:"anyOf,omitempty"`
-	Not                  *JSONSchemaProps                       `json:"not,omitempty"`
-	Properties           map[string]JSONSchemaProps             `json:"properties,omitempty"`
-	AdditionalProperties *JSONSchemaPropsOrBool                 `json:"additionalProperties,omitempty"`
-	PatternProperties    map[string]JSONSchemaProps             `json:"patternProperties,omitempty"`
-	Dependencies         JSONSchemaDependencies                 `json:"dependencies,omitempty"`
-	AdditionalItems      *JSONSchemaPropsOrBool                 `json:"additionalItems,omitempty"`
-	Definitions          JSONSchemaDefinitions                  `json:"definitions,omitempty"`
-	ExternalDocs         *apiextensionsv1.ExternalDocumentation `json:"externalDocs,omitempty"`
-	Example              *apiextensionsv1.JSON                  `json:"example,omitempty"`
-	Nullable             bool                                   `json:"nullable,omitempty"`
-
-	XPreserveUnknownFields *bool                           `json:"x-kubernetes-preserve-unknown-fields,omitempty"`
-	XEmbeddedResource      bool                            `json:"x-kubernetes-embedded-resource,omitempty"`
-	XIntOrString           bool                            `json:"x-kubernetes-int-or-string,omitempty"`
-	XListMapKeys           []string                        `json:"x-kubernetes-list-map-keys,omitempty"`
-	XListType              *string                         `json:"x-kubernetes-list-type,omitempty"`
-	XMapType               *string                         `json:"x-kubernetes-map-type,omitempty"`
-	XValidations           apiextensionsv1.ValidationRules `json:"x-kubernetes-validations,omitempty"`
+	// The positions that carry a nested schema, retargeted at this type: upstream
+	// declares them through its own JSONSchemaProps, which cannot hold XSensitiveData.
+	//
+	// Each one shadows the embedded field of the same json name, and json resolves that
+	// by depth: these are the ones serialized, the upstream ones are dropped from the
+	// field set entirely and stay nil. Never read a nested schema through the embedded
+	// struct. TestForkCoversUpstreamFields is what keeps the list complete.
+	Items                *JSONSchemaPropsOrArray    `json:"items,omitempty"`
+	AllOf                []JSONSchemaProps          `json:"allOf,omitempty"`
+	OneOf                []JSONSchemaProps          `json:"oneOf,omitempty"`
+	AnyOf                []JSONSchemaProps          `json:"anyOf,omitempty"`
+	Not                  *JSONSchemaProps           `json:"not,omitempty"`
+	Properties           map[string]JSONSchemaProps `json:"properties,omitempty"`
+	AdditionalProperties *JSONSchemaPropsOrBool     `json:"additionalProperties,omitempty"`
+	PatternProperties    map[string]JSONSchemaProps `json:"patternProperties,omitempty"`
+	Dependencies         JSONSchemaDependencies     `json:"dependencies,omitempty"`
+	AdditionalItems      *JSONSchemaPropsOrBool     `json:"additionalItems,omitempty"`
+	Definitions          JSONSchemaDefinitions      `json:"definitions,omitempty"`
 
 	// XSensitiveData marks a field (or an object/array subtree) as sensitive: the
 	// apiserver encrypts it in etcd, filters it by RBAC through the <resource>/sensitive
 	// subresource, and masks it in audit logs.
 	//
 	// This is NOT an upstream Kubernetes field. It only exists on the Deckhouse
-	// kube-apiserver, and it is the sole reason this package forks JSONSchemaProps.
+	// kube-apiserver, and it is the sole reason this package declares its own type.
 	// Keep it listed in forkOnlyFields in the test when adding others.
 	XSensitiveData bool `json:"x-kubernetes-sensitive-data,omitempty"`
 }

--- a/pkg/crd-installer/openapi/types.go
+++ b/pkg/crd-installer/openapi/types.go
@@ -18,8 +18,15 @@
 // accepted: the field is meaningless there anyway, and detecting it would mean probing
 // the apiserver build for every install.
 //
-// TestForkCoversUpstreamFields guards the copy against drift; read it before bumping
-// k8s.io/apiextensions-apiserver.
+// Being the allowlist cuts the other way too: a schema field the cluster's apiserver
+// understands and this build does not is dropped silently, and TestForkCoversUpstreamFields
+// only fires when this module bumps k8s.io/apiextensions-apiserver — never when the cluster
+// moves ahead of it. Keep the dependency in step with the apiserver Deckhouse ships. A
+// schema this fork cannot decode at all is not dropped: the installer sends that document
+// as it came and reports the error (see sanitize).
+//
+// TestForkCoversUpstreamFields and TestForkMarshalsLikeUpstream guard the copy against
+// drift; read them before bumping k8s.io/apiextensions-apiserver.
 package openapi
 
 import (

--- a/pkg/crd-installer/openapi/types_test.go
+++ b/pkg/crd-installer/openapi/types_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // forkOnlyFields are the json keys this package adds on top of upstream
@@ -18,33 +17,61 @@ var forkOnlyFields = map[string]struct{}{
 }
 
 // TestForkCoversUpstreamFields is the guard that keeps the fork honest. JSONSchemaProps
-// is copied by hand, so a k8s bump that adds a schema field would otherwise make the
-// installer silently strip that field from every CRD it applies, with no warning
-// anywhere. If this fails after bumping k8s.io/apiextensions-apiserver, port the new
-// field into types.go rather than relaxing the test.
+// is copied by hand, so a k8s bump that adds a schema field — or retypes one — would
+// otherwise make the installer silently strip or mis-decode that field on every CRD it
+// applies, with no warning anywhere. If this fails after bumping
+// k8s.io/apiextensions-apiserver, port the change into types.go rather than relaxing
+// the test.
 func TestForkCoversUpstreamFields(t *testing.T) {
-	upstream := jsonTags(reflect.TypeOf(apiextensionsv1.JSONSchemaProps{}))
-	fork := jsonTags(reflect.TypeOf(JSONSchemaProps{}))
+	upstream := jsonFields(reflect.TypeOf(apiextensionsv1.JSONSchemaProps{}))
+	fork := jsonFields(reflect.TypeOf(JSONSchemaProps{}))
 
-	for tag, name := range upstream {
-		if _, ok := fork[tag]; !ok {
-			t.Errorf("apiextensionsv1.JSONSchemaProps.%s (%q) is missing from the fork: the installer would strip it from every CRD", name, tag)
+	for tag, up := range upstream {
+		f, ok := fork[tag]
+		if !ok {
+			t.Errorf("apiextensionsv1.JSONSchemaProps.%s (%q) is missing from the fork: the installer would strip it from every CRD", up.name, tag)
+
+			continue
+		}
+
+		if f.typ != up.typ {
+			t.Errorf("JSONSchemaProps.%s (%q) is %s upstream but %s in the fork: the installer would mis-decode it", up.name, tag, up.typ, f.typ)
 		}
 	}
 
-	for tag, name := range fork {
+	for tag, f := range fork {
 		if _, ok := upstream[tag]; ok {
 			continue
 		}
 
 		if _, ok := forkOnlyFields[tag]; !ok {
-			t.Errorf("JSONSchemaProps.%s (%q) exists in neither upstream nor forkOnlyFields: the apiserver will reject it as an unknown field", name, tag)
+			t.Errorf("JSONSchemaProps.%s (%q) exists in neither upstream nor forkOnlyFields: the apiserver will reject it as an unknown field", f.name, tag)
 		}
 	}
 }
 
-func jsonTags(t reflect.Type) map[string]string {
-	out := make(map[string]string, t.NumField())
+// TestForkCoversUpstreamUnions guards the three union types. Every one of their fields is
+// json:"-" and carried by the hand-ported marshallers in marshal.go, so the tag-based
+// guard above never sees them — they are the part of the fork most likely to drift
+// unnoticed.
+func TestForkCoversUpstreamUnions(t *testing.T) {
+	for _, tc := range []struct{ fork, upstream reflect.Type }{
+		{reflect.TypeOf(JSONSchemaPropsOrArray{}), reflect.TypeOf(apiextensionsv1.JSONSchemaPropsOrArray{})},
+		{reflect.TypeOf(JSONSchemaPropsOrBool{}), reflect.TypeOf(apiextensionsv1.JSONSchemaPropsOrBool{})},
+		{reflect.TypeOf(JSONSchemaPropsOrStringArray{}), reflect.TypeOf(apiextensionsv1.JSONSchemaPropsOrStringArray{})},
+	} {
+		t.Run(tc.fork.Name(), func(t *testing.T) {
+			assert.Equal(t, structFields(tc.upstream), structFields(tc.fork),
+				"port the upstream change into types.go and marshal.go")
+		})
+	}
+}
+
+type fieldInfo struct{ name, typ string }
+
+// jsonFields maps the json tag of every serialized field to its name and type.
+func jsonFields(t reflect.Type) map[string]fieldInfo {
+	out := make(map[string]fieldInfo, t.NumField())
 
 	for i := range t.NumField() {
 		field := t.Field(i)
@@ -54,20 +81,35 @@ func jsonTags(t reflect.Type) map[string]string {
 			continue
 		}
 
-		out[tag] = field.Name
+		out[tag] = fieldInfo{name: field.Name, typ: typeName(field.Type)}
 	}
 
 	return out
+}
+
+// structFields maps every field name to its type, json:"-" ones included.
+func structFields(t reflect.Type) map[string]string {
+	out := make(map[string]string, t.NumField())
+
+	for i := range t.NumField() {
+		out[t.Field(i).Name] = typeName(t.Field(i).Type)
+	}
+
+	return out
+}
+
+// typeName renders a type with this package's name replaced by the upstream one: every
+// nested schema position is retargeted here by hand, and that is the one difference the
+// guards must look through to see the ones that matter.
+func typeName(t reflect.Type) string {
+	return strings.ReplaceAll(t.String(), "openapi.", "v1.")
 }
 
 // roundTrip runs a schema through the fork the same way the installer does.
 func roundTrip(t *testing.T, in map[string]any) map[string]any {
 	t.Helper()
 
-	props := &JSONSchemaProps{}
-	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(in, props))
-
-	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(props)
+	out, err := Prune(in)
 	require.NoError(t, err)
 
 	return out
@@ -88,6 +130,16 @@ func TestRoundTripKeepsKnownFields(t *testing.T) {
 			"token": map[string]any{
 				"type":                        "string",
 				"x-kubernetes-sensitive-data": true,
+			},
+			"port": map[string]any{
+				"type":       "integer",
+				"minimum":    int64(1),
+				"maximum":    int64(65535),
+				"multipleOf": int64(2),
+			},
+			"ratio": map[string]any{
+				"type":    "number",
+				"maximum": 1.5,
 			},
 			// items in single-schema form
 			"tags": map[string]any{
@@ -145,6 +197,16 @@ func TestRoundTripKeepsKnownFields(t *testing.T) {
 	assert.Equal(t, "a", name["default"])
 
 	assert.Equal(t, true, props["token"].(map[string]any)["x-kubernetes-sensitive-data"])
+
+	// The bounds are *float64 in Go but whole numbers on the wire, and the apiserver
+	// returns them as int64. Encoding them as float64 would make the desired spec
+	// permanently differ from the stored one and update every such CRD on every run.
+	port := props["port"].(map[string]any)
+	assert.Equal(t, int64(1), port["minimum"])
+	assert.Equal(t, int64(65535), port["maximum"])
+	assert.Equal(t, int64(2), port["multipleOf"])
+
+	assert.Equal(t, 1.5, props["ratio"].(map[string]any)["maximum"], "a fractional bound stays a float")
 
 	tags := props["tags"].(map[string]any)
 	assert.Equal(t, "set", tags["x-kubernetes-list-type"])

--- a/pkg/crd-installer/openapi/types_test.go
+++ b/pkg/crd-installer/openapi/types_test.go
@@ -1,0 +1,220 @@
+package openapi
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// forkOnlyFields are the json keys this package adds on top of upstream
+// JSONSchemaProps. Everything else must exist on both sides.
+var forkOnlyFields = map[string]struct{}{
+	"x-kubernetes-sensitive-data": {},
+}
+
+// TestForkCoversUpstreamFields is the guard that keeps the fork honest. JSONSchemaProps
+// is copied by hand, so a k8s bump that adds a schema field would otherwise make the
+// installer silently strip that field from every CRD it applies, with no warning
+// anywhere. If this fails after bumping k8s.io/apiextensions-apiserver, port the new
+// field into types.go rather than relaxing the test.
+func TestForkCoversUpstreamFields(t *testing.T) {
+	upstream := jsonTags(reflect.TypeOf(apiextensionsv1.JSONSchemaProps{}))
+	fork := jsonTags(reflect.TypeOf(JSONSchemaProps{}))
+
+	for tag, name := range upstream {
+		if _, ok := fork[tag]; !ok {
+			t.Errorf("apiextensionsv1.JSONSchemaProps.%s (%q) is missing from the fork: the installer would strip it from every CRD", name, tag)
+		}
+	}
+
+	for tag, name := range fork {
+		if _, ok := upstream[tag]; ok {
+			continue
+		}
+
+		if _, ok := forkOnlyFields[tag]; !ok {
+			t.Errorf("JSONSchemaProps.%s (%q) exists in neither upstream nor forkOnlyFields: the apiserver will reject it as an unknown field", name, tag)
+		}
+	}
+}
+
+func jsonTags(t reflect.Type) map[string]string {
+	out := make(map[string]string, t.NumField())
+
+	for i := range t.NumField() {
+		field := t.Field(i)
+
+		tag, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		out[tag] = field.Name
+	}
+
+	return out
+}
+
+// roundTrip runs a schema through the fork the same way the installer does.
+func roundTrip(t *testing.T, in map[string]any) map[string]any {
+	t.Helper()
+
+	props := &JSONSchemaProps{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(in, props))
+
+	out, err := runtime.DefaultUnstructuredConverter.ToUnstructured(props)
+	require.NoError(t, err)
+
+	return out
+}
+
+func TestRoundTripKeepsKnownFields(t *testing.T) {
+	in := map[string]any{
+		"type":                                 "object",
+		"x-kubernetes-preserve-unknown-fields": true,
+		"required":                             []any{"name"},
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":      "string",
+				"maxLength": int64(10),
+				"enum":      []any{"a", "b"},
+				"default":   "a",
+			},
+			"token": map[string]any{
+				"type":                        "string",
+				"x-kubernetes-sensitive-data": true,
+			},
+			// items in single-schema form
+			"tags": map[string]any{
+				"type":                   "array",
+				"x-kubernetes-list-type": "set",
+				"items": map[string]any{
+					"type":      "string",
+					"minLength": int64(1),
+				},
+			},
+			// items in tuple form
+			"pair": map[string]any{
+				"type": "array",
+				"items": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "integer"},
+				},
+			},
+			// additionalProperties in schema form
+			"labels": map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type":                        "string",
+					"x-kubernetes-sensitive-data": true,
+				},
+			},
+			// additionalProperties in bool form
+			"free": map[string]any{
+				"type":                 "object",
+				"additionalProperties": true,
+			},
+			"either": map[string]any{
+				"allOf": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"minLength": int64(2)},
+				},
+			},
+		},
+	}
+
+	out := roundTrip(t, in)
+
+	assert.Equal(t, "object", out["type"])
+	assert.Equal(t, true, out["x-kubernetes-preserve-unknown-fields"])
+	assert.Equal(t, []any{"name"}, out["required"])
+
+	props := out["properties"].(map[string]any)
+
+	name := props["name"].(map[string]any)
+	// Numbers must come back as int64. A plain encoding/json round trip would yield
+	// float64 here, which never compares equal to what the apiserver returns and would
+	// make the installer issue an Update on every run.
+	assert.Equal(t, int64(10), name["maxLength"])
+	assert.Equal(t, []any{"a", "b"}, name["enum"])
+	assert.Equal(t, "a", name["default"])
+
+	assert.Equal(t, true, props["token"].(map[string]any)["x-kubernetes-sensitive-data"])
+
+	tags := props["tags"].(map[string]any)
+	assert.Equal(t, "set", tags["x-kubernetes-list-type"])
+	assert.Equal(t, int64(1), tags["items"].(map[string]any)["minLength"])
+
+	pair := props["pair"].(map[string]any)["items"].([]any)
+	require.Len(t, pair, 2)
+	assert.Equal(t, "integer", pair[1].(map[string]any)["type"])
+
+	labels := props["labels"].(map[string]any)["additionalProperties"].(map[string]any)
+	assert.Equal(t, true, labels["x-kubernetes-sensitive-data"],
+		"the extension must survive inside additionalProperties too")
+
+	assert.Equal(t, true, props["free"].(map[string]any)["additionalProperties"])
+
+	either := props["either"].(map[string]any)["allOf"].([]any)
+	require.Len(t, either, 2)
+	assert.Equal(t, int64(2), either[1].(map[string]any)["minLength"])
+}
+
+func TestRoundTripDropsUnknownFields(t *testing.T) {
+	in := map[string]any{
+		"type":           "object",
+		"x-doc-examples": []any{"root"},
+		"x-description":  "root",
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":                        "string",
+				"x-doc-examples":              []any{"nested"},
+				"x-doc-default":               "nested",
+				"x-examples":                  []any{"nested"},
+				"x-kubernetes-immutable":      true,
+				"x-kubernetes-patch-strategy": "merge",
+			},
+			"tags": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":           "string",
+					"x-doc-examples": []any{"in items"},
+				},
+			},
+			"labels": map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type":           "string",
+					"x-doc-examples": []any{"in additionalProperties"},
+				},
+			},
+		},
+	}
+
+	out := roundTrip(t, in)
+
+	assert.NotContains(t, out, "x-doc-examples")
+	assert.NotContains(t, out, "x-description")
+
+	props := out["properties"].(map[string]any)
+
+	name := props["name"].(map[string]any)
+	assert.Equal(t, "string", name["type"], "known fields must survive alongside the dropped ones")
+
+	for _, key := range []string{
+		"x-doc-examples", "x-doc-default", "x-examples",
+		// these two look official but are not in JSONSchemaProps, so a
+		// x-kubernetes-* prefix rule would have let them through
+		"x-kubernetes-immutable", "x-kubernetes-patch-strategy",
+	} {
+		assert.NotContains(t, name, key)
+	}
+
+	assert.NotContains(t, props["tags"].(map[string]any)["items"].(map[string]any), "x-doc-examples")
+	assert.NotContains(t, props["labels"].(map[string]any)["additionalProperties"].(map[string]any), "x-doc-examples")
+}

--- a/pkg/crd-installer/openapi/types_test.go
+++ b/pkg/crd-installer/openapi/types_test.go
@@ -34,8 +34,12 @@ func TestForkCoversUpstreamFields(t *testing.T) {
 			continue
 		}
 
-		if f.typ != up.typ {
-			t.Errorf("JSONSchemaProps.%s (%q) is %s upstream but %s in the fork: the installer would mis-decode it", up.name, tag, up.typ, f.typ)
+		if want := forkType(up.typ); f.typ != want {
+			t.Errorf("JSONSchemaProps.%s (%q) is %s upstream, so the fork must declare it %s, not %s: the installer would mis-decode it", up.name, tag, up.typ, want, f.typ)
+		}
+
+		if f.opts != up.opts {
+			t.Errorf("JSONSchemaProps.%s (%q) has the json tag options %q upstream but %q in the fork: the installer would serialize it where the apiserver omits it, and every CRD would be updated on every reconcile", up.name, tag, up.opts, f.opts)
 		}
 	}
 
@@ -61,27 +65,29 @@ func TestForkCoversUpstreamUnions(t *testing.T) {
 		{reflect.TypeOf(JSONSchemaPropsOrStringArray{}), reflect.TypeOf(apiextensionsv1.JSONSchemaPropsOrStringArray{})},
 	} {
 		t.Run(tc.fork.Name(), func(t *testing.T) {
-			assert.Equal(t, structFields(tc.upstream), structFields(tc.fork),
+			assert.Equal(t, forkStructFields(tc.upstream), structFields(tc.fork),
 				"port the upstream change into types.go and marshal.go")
 		})
 	}
 }
 
-type fieldInfo struct{ name, typ string }
+type fieldInfo struct{ name, typ, opts string }
 
-// jsonFields maps the json tag of every serialized field to its name and type.
+// jsonFields maps the json tag name of every serialized field to its name, type and tag
+// options. The options are part of the contract: a field that lost omitempty is serialized
+// where the apiserver omits it, and the desired spec could never equal the stored one again.
 func jsonFields(t reflect.Type) map[string]fieldInfo {
 	out := make(map[string]fieldInfo, t.NumField())
 
 	for i := range t.NumField() {
 		field := t.Field(i)
 
-		tag, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		tag, opts, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if tag == "" || tag == "-" {
 			continue
 		}
 
-		out[tag] = fieldInfo{name: field.Name, typ: typeName(field.Type)}
+		out[tag] = fieldInfo{name: field.Name, typ: field.Type.String(), opts: opts}
 	}
 
 	return out
@@ -92,17 +98,45 @@ func structFields(t reflect.Type) map[string]string {
 	out := make(map[string]string, t.NumField())
 
 	for i := range t.NumField() {
-		out[t.Field(i).Name] = typeName(t.Field(i).Type)
+		out[t.Field(i).Name] = t.Field(i).Type.String()
 	}
 
 	return out
 }
 
-// typeName renders a type with this package's name replaced by the upstream one: every
-// nested schema position is retargeted here by hand, and that is the one difference the
-// guards must look through to see the ones that matter.
-func typeName(t reflect.Type) string {
-	return strings.ReplaceAll(t.String(), "openapi.", "v1.")
+// forkStructFields is structFields with every type rendered as the fork must declare it.
+func forkStructFields(t reflect.Type) map[string]string {
+	out := structFields(t)
+
+	for name, typ := range out {
+		out[name] = forkType(typ)
+	}
+
+	return out
+}
+
+// forkTypes are the upstream types this package retargets at itself. Every other type a
+// field can hold — v1.JSON, v1.JSONSchemaURL, v1.ValidationRules — must stay upstream.
+var forkTypes = []string{
+	"JSONSchemaProps",
+	"JSONSchemaPropsOrArray",
+	"JSONSchemaPropsOrBool",
+	"JSONSchemaPropsOrStringArray",
+	"JSONSchemaDependencies",
+	"JSONSchemaDefinitions",
+}
+
+// forkType renders an upstream field type as the fork must declare it. The mapping runs in
+// this direction on purpose: erasing the package name on both sides instead would let a
+// nested schema position left pointing at apiextensionsv1 compare equal — and that is the
+// one drift these guards exist to catch, because Prune would then silently strip
+// x-kubernetes-sensitive-data from every schema under it.
+func forkType(upstream string) string {
+	for _, name := range forkTypes {
+		upstream = strings.ReplaceAll(upstream, "v1."+name, "openapi."+name)
+	}
+
+	return upstream
 }
 
 // roundTrip runs a schema through the fork the same way the installer does.

--- a/pkg/crd-installer/openapi/types_test.go
+++ b/pkg/crd-installer/openapi/types_test.go
@@ -16,15 +16,16 @@ var forkOnlyFields = map[string]struct{}{
 	"x-kubernetes-sensitive-data": {},
 }
 
-// TestForkCoversUpstreamFields is the guard that keeps the fork honest. JSONSchemaProps
-// is copied by hand, so a k8s bump that adds a schema field — or retypes one — would
-// otherwise make the installer silently strip or mis-decode that field on every CRD it
-// applies, with no warning anywhere. If this fails after bumping
-// k8s.io/apiextensions-apiserver, port the change into types.go rather than relaxing
-// the test.
+// TestForkCoversUpstreamFields is the guard that keeps the fork honest. Embedding the
+// upstream type makes the plain schema fields impossible to get wrong, but the nested
+// schema positions are still declared by hand: a k8s bump that adds one — a new keyword
+// holding a JSONSchemaProps — would leave it inherited as the upstream type, and Prune
+// would then silently strip x-kubernetes-sensitive-data from every schema under it, with
+// no warning anywhere. If this fails after bumping k8s.io/apiextensions-apiserver, port
+// the change into types.go rather than relaxing the test.
 func TestForkCoversUpstreamFields(t *testing.T) {
-	upstream := jsonFields(reflect.TypeOf(apiextensionsv1.JSONSchemaProps{}))
-	fork := jsonFields(reflect.TypeOf(JSONSchemaProps{}))
+	upstream := jsonFields(t, reflect.TypeOf(apiextensionsv1.JSONSchemaProps{}))
+	fork := jsonFields(t, reflect.TypeOf(JSONSchemaProps{}))
 
 	for tag, up := range upstream {
 		f, ok := fork[tag]
@@ -76,15 +77,26 @@ type fieldInfo struct{ name, typ, opts string }
 // jsonFields maps the json tag name of every serialized field to its name, type and tag
 // options. The options are part of the contract: a field that lost omitempty is serialized
 // where the apiserver omits it, and the desired spec could never equal the stored one again.
-func jsonFields(t reflect.Type) map[string]fieldInfo {
-	out := make(map[string]fieldInfo, t.NumField())
+//
+// Fields promoted from an embedded struct are included, and a shadowed one is not:
+// reflect resolves those by depth exactly as json does, so this is the field set json
+// will actually serialize. The embedded field itself carries no json name and drops out.
+func jsonFields(t *testing.T, typ reflect.Type) map[string]fieldInfo {
+	t.Helper()
 
-	for i := range t.NumField() {
-		field := t.Field(i)
+	out := make(map[string]fieldInfo, typ.NumField())
 
+	for _, field := range reflect.VisibleFields(typ) {
 		tag, opts, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if tag == "" || tag == "-" {
 			continue
+		}
+
+		// two visible fields with one json name are not a shadow, they are a collision:
+		// json drops both, and the key would vanish from every CRD this installs
+		if dup, ok := out[tag]; ok {
+			t.Fatalf("%s.%s and .%s both claim the json name %q: json serializes neither",
+				typ, dup.name, field.Name, tag)
 		}
 
 		out[tag] = fieldInfo{name: field.Name, typ: field.Type.String(), opts: opts}

--- a/pkg/crd-installer/testdata/10_multi_document.yaml
+++ b/pkg/crd-installer/testdata/10_multi_document.yaml
@@ -1,0 +1,65 @@
+# Three CRDs in one file, the middle one broken: x-kubernetes-sensitive-data is a bool,
+# so the schema cannot be decoded. The other two must still be installed.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: firsts.example.com
+spec:
+  group: example.com
+  names:
+    kind: First
+    listKind: FirstList
+    plural: firsts
+    singular: first
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: broken.example.com
+spec:
+  group: example.com
+  names:
+    kind: Broken
+    listKind: BrokenList
+    plural: broken
+    singular: broken
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            token:
+              type: string
+              x-kubernetes-sensitive-data: "yes"
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: lasts.example.com
+spec:
+  group: example.com
+  names:
+    kind: Last
+    listKind: LastList
+    plural: lasts
+    singular: last
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/pkg/crd-installer/testdata/6_unknown_extensions.yaml
+++ b/pkg/crd-installer/testdata/6_unknown_extensions.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: extensions.example.com
+spec:
+  group: example.com
+  names:
+    kind: Extension
+    listKind: ExtensionList
+    plural: extensions
+    singular: extension
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-doc-examples:
+            - at the root
+          x-description: at the root
+          properties:
+            spec:
+              type: object
+              properties:
+                token:
+                  type: string
+                  x-kubernetes-sensitive-data: true
+                  x-doc-examples:
+                    - next to a field that must survive
+                tags:
+                  type: array
+                  x-kubernetes-list-type: set
+                  items:
+                    type: string
+                    minLength: 1
+                    x-doc-examples:
+                      - inside items
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                    x-doc-examples:
+                      - inside additionalProperties
+                free:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                # keys that look official but are not fields of JSONSchemaProps,
+                # so a "keep everything x-kubernetes-*" rule would leak them
+                legacy:
+                  type: string
+                  x-kubernetes-immutable: true
+                  x-kubernetes-patch-strategy: merge
+                  x-examples:
+                    - legacy
+                  x-doc-default: legacy

--- a/pkg/crd-installer/testdata/6_unknown_extensions.yaml
+++ b/pkg/crd-installer/testdata/6_unknown_extensions.yaml
@@ -19,39 +19,13 @@ spec:
           type: object
           x-doc-examples:
             - at the root
-          x-description: at the root
           properties:
             spec:
               type: object
               properties:
                 token:
                   type: string
+                  # the one extension that must survive, next to one that must not
                   x-kubernetes-sensitive-data: true
                   x-doc-examples:
-                    - next to a field that must survive
-                tags:
-                  type: array
-                  x-kubernetes-list-type: set
-                  items:
-                    type: string
-                    minLength: 1
-                    x-doc-examples:
-                      - inside items
-                labels:
-                  type: object
-                  additionalProperties:
-                    type: string
-                    x-doc-examples:
-                      - inside additionalProperties
-                free:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                # keys that look official but are not fields of JSONSchemaProps,
-                # so a "keep everything x-kubernetes-*" rule would leak them
-                legacy:
-                  type: string
-                  x-kubernetes-immutable: true
-                  x-kubernetes-patch-strategy: merge
-                  x-examples:
-                    - legacy
-                  x-doc-default: legacy
+                    - deep in the tree

--- a/pkg/crd-installer/testdata/7_churn_stored.yaml
+++ b/pkg/crd-installer/testdata/7_churn_stored.yaml
@@ -1,0 +1,29 @@
+# What the apiserver ends up storing for 8_churn_manifest.yaml: the same CRD with the
+# x-doc-* keys pruned away. Installing this first puts the fake client into the state a
+# real cluster would be in, which is the only way to reproduce the reconcile churn.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: churns.example.com
+spec:
+  group: example.com
+  names:
+    kind: Churn
+    listKind: ChurnList
+    plural: churns
+    singular: churn
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                token:
+                  type: string
+                  x-kubernetes-sensitive-data: true

--- a/pkg/crd-installer/testdata/7_churn_stored.yaml
+++ b/pkg/crd-installer/testdata/7_churn_stored.yaml
@@ -1,6 +1,7 @@
-# What the apiserver ends up storing for 8_churn_manifest.yaml: the same CRD with the
-# x-doc-* keys pruned away. Installing this first puts the fake client into the state a
-# real cluster would be in, which is the only way to reproduce the reconcile churn.
+# What the apiserver ends up storing for 8_churn_manifest.yaml: the x-doc-* keys pruned
+# away and spec.names.singular/listKind defaulted in. Installing this first puts the fake
+# client into the state a real cluster would be in, which is the only way to reproduce the
+# reconcile churn.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -27,3 +28,8 @@ spec:
                 token:
                   type: string
                   x-kubernetes-sensitive-data: true
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  multipleOf: 2

--- a/pkg/crd-installer/testdata/7_churn_stored.yaml
+++ b/pkg/crd-installer/testdata/7_churn_stored.yaml
@@ -33,3 +33,11 @@ spec:
                   minimum: 1
                   maximum: 65535
                   multipleOf: 2
+    - name: v1alpha1
+      served: true
+      # the manifest omits this one: served and storage have no omitempty upstream, so the
+      # stored object carries both on every version no matter what the manifest says
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/pkg/crd-installer/testdata/8_churn_manifest.yaml
+++ b/pkg/crd-installer/testdata/8_churn_manifest.yaml
@@ -38,3 +38,8 @@ spec:
                   multipleOf: 2
                   x-doc-examples:
                     - 8080
+    - name: v1alpha1
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/pkg/crd-installer/testdata/8_churn_manifest.yaml
+++ b/pkg/crd-installer/testdata/8_churn_manifest.yaml
@@ -1,0 +1,34 @@
+# 7_churn_stored.yaml plus the x-doc-* keys a module actually ships. Applying this over
+# the stored state must be a no-op: the doc keys never reach the cluster, so there is
+# nothing to reconcile.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: churns.example.com
+spec:
+  group: example.com
+  names:
+    kind: Churn
+    listKind: ChurnList
+    plural: churns
+    singular: churn
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-doc-examples:
+            - at the root
+          properties:
+            spec:
+              type: object
+              properties:
+                token:
+                  type: string
+                  x-kubernetes-sensitive-data: true
+                  x-doc-default: ""
+                  x-doc-examples:
+                    - a token

--- a/pkg/crd-installer/testdata/8_churn_manifest.yaml
+++ b/pkg/crd-installer/testdata/8_churn_manifest.yaml
@@ -1,6 +1,7 @@
-# 7_churn_stored.yaml plus the x-doc-* keys a module actually ships. Applying this over
-# the stored state must be a no-op: the doc keys never reach the cluster, so there is
-# nothing to reconcile.
+# The CRD as a module actually ships it: x-doc-* keys the apiserver prunes, whole-number
+# bounds it returns as int64, and no spec.names.singular/listKind because it defaults
+# those itself. Applying this over 7_churn_stored.yaml must be a no-op — there is nothing
+# the cluster does not already have.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -9,9 +10,7 @@ spec:
   group: example.com
   names:
     kind: Churn
-    listKind: ChurnList
     plural: churns
-    singular: churn
   scope: Namespaced
   versions:
     - name: v1
@@ -32,3 +31,10 @@ spec:
                   x-doc-default: ""
                   x-doc-examples:
                     - a token
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  multipleOf: 2
+                  x-doc-examples:
+                    - 8080

--- a/pkg/crd-installer/testdata/9_unknown_crd_field.yaml
+++ b/pkg/crd-installer/testdata/9_unknown_crd_field.yaml
@@ -1,0 +1,23 @@
+# A CRD carrying a field outside the schema that this build's apiextensions-apiserver
+# does not model — a newer Kubernetes, or a Deckhouse apiserver patch. It must reach the
+# cluster untouched: only schemas are pruned.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: futures.example.com
+spec:
+  group: example.com
+  names:
+    kind: Future
+    listKind: FutureList
+    plural: futures
+    singular: future
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      fieldFromTheFuture: a field from a newer apiserver
+      schema:
+        openAPIV3Schema:
+          type: object


### PR DESCRIPTION
## Description

Prune CRD validation schemas to the fields the apiserver actually knows before applying
them, normalize the fields it fills in itself, and stop rewriting metadata that belongs to
other actors.

New package `pkg/crd-installer/openapi`:

- `JSONSchemaProps` embeds `apiextensionsv1.JSONSchemaProps` and adds
  `x-kubernetes-sensitive-data`; only the positions that carry a nested schema
  (`properties`, `items`, `allOf`, `additionalProperties`, …) are redeclared, so the
  extension survives at any depth. Union marshallers are ported from upstream;
- `Prune` decodes a schema through that type and re-encodes it, so every key that is not a
  schema field is dropped and whole numbers come back as `int64` — exactly as the apiserver
  returns them;
- drift guards: every nested-schema position retargeted at this type (a new one added
  upstream fails the test), no two fields claiming one json name, union field sets, and a
  byte-for-byte comparison of the marshalled output against upstream's.

Installer:

- `sanitize` rewrites only `spec.versions[*].schema.openAPIV3Schema`; the rest of the
  document is passed through untouched, so a CRD field only a newer or patched apiserver
  models still reaches it;
- `applyServerDefaults` writes what the apiserver fills in itself — `spec.names.singular`,
  `spec.names.listKind`, and `served`/`storage` on every version (neither has `omitempty`
  upstream, so the stored object always carries both);
- the update compares the lossless unstructured `.spec`, labels and annotations against the
  state the object must end up holding, and returns early when nothing differs;
- labels and annotations are overlaid, never replaced, so keys written by other actors
  survive;
- a document that cannot be read or sanitized no longer aborts the file: the remaining
  documents are still applied, all errors are joined, and a schema this build cannot decode
  is sent as it came rather than keeping the CRD out of the cluster.

## Why do we need it, and what problem does it solve?

**Reconcile churn.** Since CRDs are applied verbatim (#122), the desired `.spec` carried
keys the apiserver prunes (`x-doc-examples`, `x-doc-default`, `x-examples`,
`x-kubernetes-immutable`, …), omitted the `.spec` fields it defaults, and encoded whole
numbers as `float64`. The stored spec could therefore never equal the desired one, so every
`ensure_crds` run — i.e. the startup of every module — issued a full `Update` of nearly
every CRD, bumping `resourceVersion` and re-waking every CRD informer in the cluster. The
apiserver also logged one "unknown field" warning per pruned key on every apply.

**Vendor extensions still have to survive.** `x-kubernetes-sensitive-data` only exists on
the Deckhouse apiserver, and the upstream Go type cannot hold it — dropping it would stop
the marked fields from being encrypted in etcd, RBAC-filtered and masked in audit logs.
That is the sole reason the type is declared here at all instead of using
`apiextensionsv1.JSONSchemaProps` directly.

**Foreign metadata was deleted.** Replacing `metadata.labels` and `metadata.annotations`
wholesale dropped Helm's ownership keys — `app.kubernetes.io/managed-by` among the labels,
`meta.helm.sh/release-name` and `-namespace` among the annotations — so the next
`helm upgrade` of the chart that installed the CRD failed on
`invalid ownership metadata`.

**One bad document took the file down with it.** An undecodable document aborted
`processCRD`, silently skipping every CRD after it in the same file, and a schema this build
cannot decode kept the CRD itself out of the cluster — which rejects every custom resource
of that kind as an unknown kind.

## What is the expected behaviour?

- Applying a manifest over the state the apiserver derived from it is a no-op: no `Update`,
  no `generation` bump, no informer wakeups.
- Keys the apiserver does not know never leave the installer for schemas, so the
  "unknown field" warnings are gone.
- `x-kubernetes-sensitive-data` reaches the cluster, at every nesting position
  (`properties`, `items`, `additionalProperties`, `allOf`, …).
- Labels and annotations written by Helm, kubectl or an operator survive every update;
  server-managed metadata (`finalizers`, `ownerReferences`, `uid`) and the in-cluster
  `spec.conversion` are preserved as before.
- A broken document is reported and the rest of the file is still installed.

## Deliberate trade-offs

- **`.spec` keys outside the schema are still sent.** If this cluster's apiserver prunes one
  (`selectableFields` on an older cluster, `x-kubernetes-sensitive-data` on a stock control
  plane), that single CRD is updated on every reconcile. Accepted: the key is sent so an
  apiserver that does know it gets it.
- **Metadata keys are never deleted.** A label or annotation the manifest stops declaring
  stays in the cluster; retracting one needs the field ownership the apiserver keeps for
  server-side apply, which would mean switching the whole update to `Apply`.
- **The type is the allowlist in both directions.** A schema field a newer apiserver
  understands and this build does not is dropped silently; the drift guards only fire when
  this module bumps `k8s.io/apiextensions-apiserver` — keep the dependency in step with the
  apiserver Deckhouse ships. Plain fields then follow the bump by themselves; a new position
  holding a nested schema still has to be redeclared by hand, and the guard is what says so.

## Tests

New regression subtests in `pkg/crd-installer`:

- unknown schema extensions are stripped while `x-kubernetes-sensitive-data` survives;
- a CRD field outside the schema reaches the cluster and does not churn;
- applying a manifest over its stored form (`7_churn_stored.yaml` → `8_churn_manifest.yaml`,
  including a version whose `storage` the manifest omits) issues zero updates;
- a bad document does not skip the rest of the file, and its own CRD is still installed with
  the schema sent as it came;
- Helm's ownership label and annotation survive an update, and neither reads as a diff on
  the next run — on a fake client seeded by the subtest itself, so it holds in isolation.

In `pkg/crd-installer/openapi`: schema round-trip tests for kept and dropped keys, plus the
drift guards above. Each fix was checked by reverting it and confirming the matching test
fails — including dropping one nested-schema override, which fails both the guard and the
round-trip.